### PR TITLE
Parameter modification

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,4 +31,4 @@ ADD http://www.timeapi.org/utc/now /tmp/bustcache
 RUN git pull
 
 # default process
-CMD python -u vdb/flu_download.py -db vdb -v flu --select locus:HA subtype:h3n2 --interval collection_date:2016-01-01,2016-01-15 --pick_longest --fstem h3n2
+CMD python -u vdb/flu_download.py -db vdb -v flu --select locus:HA subtype:h3n2 --interval collection_date:2016-01-01,2016-01-15 --fstem h3n2

--- a/vdb/README.md
+++ b/vdb/README.md
@@ -137,8 +137,8 @@ Subset documents with these commands
 * `--present`: Select specific fields to be non-null eg. `--present field1 field2`
 * `--interval`: Select date fields to be in a certain interval eg. `--interval collection_date:2016-01-01,2016-01-15`
 
-Prevent the default of resolving duplicate sequences for the same locus with this argument
-* `--keep_duplicates`: keep all duplicate sequences for the same locus
+Choose method of resolving duplicate sequences for the same locus
+* `--resolve_method`: keep_duplicates or choose_longest (default is to choose the longest sequence)
 
 ### Examples
 

--- a/vdb/README.md
+++ b/vdb/README.md
@@ -137,8 +137,8 @@ Subset documents with these commands
 * `--present`: Select specific fields to be non-null eg. `--present field1 field2`
 * `--interval`: Select date fields to be in a certain interval eg. `--interval collection_date:2016-01-01,2016-01-15`
 
-Resolve duplicate sequences for the same locus with these arguments
-* `--pick_longest`: pick the longest sequence
+Prevent the default of resolving duplicate sequences for the same locus with thi argument
+* `--keep_duplicates`: keep all duplicate sequences for the same locus
 
 ### Examples
 
@@ -154,7 +154,7 @@ Download sequences from `flu_download.py`:
 
     python vdb/download.py -db vdb -v zika --ftype json --countries brazil haiti --public_only
 
-    python vdb/flu_download.py -db test_vdb -v flu --select locus:HA --present age --interval collection_date:2016-01-01,2016-01-15 --pick_longest
+    python vdb/flu_download.py -db test_vdb -v flu --select locus:HA --present age --interval collection_date:2016-01-01,2016-01-15
 
 ## Updating
 

--- a/vdb/README.md
+++ b/vdb/README.md
@@ -137,7 +137,7 @@ Subset documents with these commands
 * `--present`: Select specific fields to be non-null eg. `--present field1 field2`
 * `--interval`: Select date fields to be in a certain interval eg. `--interval collection_date:2016-01-01,2016-01-15`
 
-Prevent the default of resolving duplicate sequences for the same locus with thi argument
+Prevent the default of resolving duplicate sequences for the same locus with this argument
 * `--keep_duplicates`: keep all duplicate sequences for the same locus
 
 ### Examples

--- a/vdb/download.py
+++ b/vdb/download.py
@@ -2,6 +2,7 @@ import os, json, datetime, sys, re
 import rethinkdb as r
 from Bio import SeqIO
 import numpy as np
+
 sys.path.append('')  # need to import from base
 from base.rethink_io import rethink_io
 
@@ -24,6 +25,7 @@ def get_parser():
     parser.add_argument('--interval', nargs='+', type=str, default=[], help="Select interval of values for fields \'--interval field1:value1,value2 field2:value1,value2\'")
     parser.add_argument('--years_back', type=str, default=None, help='number of past years to sample sequences from \'--years_back field:value\'')
     parser.add_argument('--relaxed_interval', default=False, action="store_true", help="Relaxed comparison to date interval, 2016-XX-XX in 2016-01-01 - 2016-03-01")
+    parser.add_argument('--keep_duplicates', action="store_true", help="Prevent action of resolving duplicates by choosing the longest sequence")
     return parser
 
 class download(object):
@@ -178,9 +180,9 @@ class download(object):
             raise Exception("Date interval must be in YYYY-MM-DD format with all values defined", older_date, newer_date)
         return(older_date.upper(), newer_date.upper())
 
-    def resolve_duplicates(self, sequences, pick_longest=True, **kwargs):
+    def resolve_duplicates(self, sequences, keep_duplicates=False, **kwargs):
         strain_locus_to_doc = {doc['strain']+doc['locus']: doc for doc in sequences}
-        if pick_longest:
+        if not keep_duplicates:
             print("Resolving duplicate strains and locus by picking the longest sequence")
             for doc in sequences:
                 if doc['strain']+doc['locus'] in strain_locus_to_doc:

--- a/vdb/download.py
+++ b/vdb/download.py
@@ -6,27 +6,29 @@ import numpy as np
 sys.path.append('')  # need to import from base
 from base.rethink_io import rethink_io
 
+
 def get_parser():
     import argparse
     parser = argparse.ArgumentParser()
     parser.add_argument('-db', '--database', default='vdb', help="database to download from")
-    parser.add_argument('--rethink_host', default=None, help="rethink host url")
-    parser.add_argument('--auth_key', default=None, help="auth_key for rethink database")
-    parser.add_argument('--local', default=False, action="store_true",  help ="connect to local instance of rethinkdb database")
+    parser.add_argument('--rethink_host', help="rethink host url")
+    parser.add_argument('--auth_key', help="auth_key for rethink database")
+    parser.add_argument('--local', action="store_true",  help ="connect to local instance of rethinkdb database")
     parser.add_argument('-v', '--virus', help="virus name")
     parser.add_argument('--ftype', default='fasta', help="output file format, default \"fasta\", other options are \"json\" and \"tsv\"")
-    parser.add_argument('--fstem', default=None, help="default output file name is \"VirusName_Year_Month_Date\"")
+    parser.add_argument('--fstem', help="default output file name is \"VirusName_Year_Month_Date\"")
     parser.add_argument('--path', default='data', help="path to dump output files to")
     parser.add_argument('--fasta_fields', default=['strain', 'virus', 'accession', 'collection_date', 'region', 'country', 'division', 'location', 'source', 'locus', 'authors'], help="fasta fields for output fasta")
 
-    parser.add_argument('--public_only', default=False, action="store_true", help="include to subset public sequences")
+    parser.add_argument('--public_only', action="store_true", help="include to subset public sequences")
     parser.add_argument('--select', nargs='+', type=str, default=[], help="Select specific fields ie \'--select field1:value1 field2:value1,value2\'")
     parser.add_argument('--present', nargs='+', type=str, default=[], help="Select specific fields to be non-null ie \'--present field1 field2\'")
     parser.add_argument('--interval', nargs='+', type=str, default=[], help="Select interval of values for fields \'--interval field1:value1,value2 field2:value1,value2\'")
-    parser.add_argument('--years_back', type=str, default=None, help='number of past years to sample sequences from \'--years_back field:value\'')
-    parser.add_argument('--relaxed_interval', default=False, action="store_true", help="Relaxed comparison to date interval, 2016-XX-XX in 2016-01-01 - 2016-03-01")
-    parser.add_argument('--keep_duplicates', action="store_true", help="Prevent action of resolving duplicates by choosing the longest sequence")
+    parser.add_argument('--years_back', type=str, help='number of past years to sample sequences from \'--years_back field:value\'')
+    parser.add_argument('--relaxed_interval', action="store_true", help="Relaxed comparison to date interval, 2016-XX-XX in 2016-01-01 - 2016-03-01")
+    parser.add_argument('--keep_duplicates', action="store_true", help="Prevent default action of only keeping the longest sequence for duplicates of the same locus")
     return parser
+
 
 class download(object):
     def __init__(self, database, virus, **kwargs):


### PR DESCRIPTION
I noticed that the **pick_longest** parameter was not in the **ArgumentParser** so I wanted to add that parameter. 

I also noticed **resolve_duplicates** was setting pick_longest to be True as default
>def resolve_duplicates(self, sequences, pick_longest=True, **kwargs):

so pick_longest was only useful when the user specified _pick\_longest=False_. I took this to mean that the most common use case (or the one we would like to encourage) is for users to remove duplicate sequences when they are not necessary.

I changed the parameter to be the opposite, **keep_duplicates**, in hope that it will be more intuitive for the user :)
>python -u vdb/flu_download.py -db vdb -v flu --keep_duplicates


I also deleted some default settings as argparse already sets them as default.