### PR TITLE
Parse subtype from document field

### DIFF
--- a/tdb/cdc_upload.py
+++ b/tdb/cdc_upload.py
@@ -52,6 +52,7 @@ class cdc_upload(upload):
             self.test_location(meas['virus_strain'])
             self.test_location(meas['serum_strain'])
             self.add_attributes(meas, **kwargs)
+            self.format_subtype(meas)            
             meas['date'] = meas['assay_date']
             self.format_date(meas)
             self.format_passage(meas, 'serum_antigen_passage', 'serum_passage_category')

--- a/tdb/upload.py
+++ b/tdb/upload.py
@@ -29,7 +29,8 @@ class upload(parse, flu_upload):
         flu_upload.__init__(self, database=database, virus=virus)
         self.virus = virus.lower()
         self.table = self.virus
-        self.subtype = subtype.lower()
+        if subtype is not None:
+            self.subtype = subtype.lower()
         self.database = database.lower()
         self.uploadable_databases = ['tdb', 'test_tdb', 'test', 'test_tdb_2']
         if self.database not in self.uploadable_databases:
@@ -97,6 +98,7 @@ class upload(parse, flu_upload):
             self.test_location(meas['virus_strain'])
             self.test_location(meas['serum_strain'])
             self.add_attributes(meas, **kwargs)
+            self.format_subtype(meas)
             self.format_date(meas)
             self.format_passage(meas, 'serum_passage', 'serum_passage_category')
             self.format_passage(meas, 'virus_passage', 'virus_passage_category')
@@ -202,7 +204,8 @@ class upload(parse, flu_upload):
         Add attributes to titer measurements
         '''
         meas['virus'] = self.virus.lower()
-        meas['subtype'] = self.subtype.lower()
+        if hasattr(self, 'subtype'):
+            meas['subtype'] = self.subtype.lower()
         meas['host'] = host.lower()
         meas['timestamp'] = self.rethink_io.get_upload_timestamp()
         meas['inclusion_date'] = self.rethink_io.get_upload_date()
@@ -325,6 +328,22 @@ class upload(parse, flu_upload):
                 print("Couldn't parse reference status", meas['ref'])
         else:
             meas['ref'] = None
+
+    def format_subtype(self, meas):
+        '''
+        Format subtype attribute
+        '''
+        if 'subtype' in meas:
+            if meas['subtype'] == 'H3':
+                meas['subtype'] = 'h3n2'
+            elif meas['subtype'] == 'H1 swl':
+                meas['subtype'] = 'h1n1pdm'
+            elif meas['subtype'] == 'B vic':
+                meas['subtype'] = 'vic'
+            elif meas['subtype'] == 'B yam':
+                meas['subtype'] = 'yam'
+        else:
+            meas['subtype'] = None
 
     def format_serum_sample(self,meas):
         '''

--- a/tdb/upload_all.py
+++ b/tdb/upload_all.py
@@ -60,21 +60,21 @@ def upload_nimr(database, nimr_path, subtype):
 
     print "Done uploading NIMR documents."
 
-def upload_cdc(database, cdc_path, subtype):
+def upload_cdc(database, cdc_path):
     '''
     Makes calls to tdb/upload.py for every flat file in an CDC titer directory (default data/cdc/).
-    All files in the directory should be flat titer files in TSV format for only one subtype
-    of virus (H3N2, H1N1pdm, etc.).
+    All files in the directory should be flat titer files in TSV format.
+    There are multiple subtypes within a file.
     '''
-    path = cdc_path + subtype + "/"
-    print "Uploading CDC data for subtype", subtype, "contained in directory", path + "."
+    path = cdc_path
+    print "Uploading CDC data contained in directory", path + "."
 
     for fname in os.listdir(path):
         if fname[0] != '.':
             fpath = path + fname
             fstem = fname[:-4]
             print "Uploading " + fname
-            command = "python tdb/cdc_upload.py -db " + database + " --subtype " + subtype + " --path " + path + " --fstem " + fstem
+            command = "python tdb/cdc_upload.py -db " + database + " --path " + path + " --fstem " + fstem
             print "Running with: " + command
             subprocess.call(command, shell=True)
             print "Done with", fname + "."


### PR DESCRIPTION
This will now set subtype to something passed in from the command line, like `--subtype h3n2`, but if `--subtype` is absent from the command line, it will look for the subtype field within the document. The function `format_subtype` canonicalizes subtype names.

Fixes #51.