### PR TITLE
Improve downloading of assay_type selections

### DIFF
--- a/flu/download_all.py
+++ b/flu/download_all.py
@@ -4,7 +4,8 @@
 # 3. Download titer tables from database
 # 4. Copy titer tables to nextflu directory
 # Run from base fauna directory with python flu/download_all.py
-# Requires files gisaid_epiflu.xls and gisaid_epiflu.fasta in data/
+# Assumes that nextflu/, nextflu-cdc/ and nextflu-cdc-fra/ are
+# sister directories to fauna/
 
 import os
 
@@ -20,11 +21,23 @@ os.system("cp data/h1n1pdm.fasta ../nextflu/augur/data/")
 os.system("cp data/vic.fasta ../nextflu/augur/data/")
 os.system("cp data/yam.fasta ../nextflu/augur/data/")
 
-# Download titer tables from database
-os.system("python tdb/download.py -db tdb -v flu --ftype augur --subtype h3n2")
-os.system("python tdb/download.py -db tdb -v flu --ftype augur --subtype h1n1pdm")
-os.system("python tdb/download.py -db tdb -v flu --ftype augur --subtype vic")
-os.system("python tdb/download.py -db tdb -v flu --ftype augur --subtype yam")
+# Copy FASTAs to nextflu-cdc directory
+os.system("cp data/h3n2.fasta ../nextflu-cdc/augur/data/")
+os.system("cp data/h1n1pdm.fasta ../nextflu-cdc/augur/data/")
+os.system("cp data/vic.fasta ../nextflu-cdc/augur/data/")
+os.system("cp data/yam.fasta ../nextflu-cdc/augur/data/")
+
+# Copy FASTAs to nextflu-cdc-fra directory
+os.system("cp data/h3n2.fasta ../nextflu-cdc-fra/augur/data/")
+os.system("cp data/h1n1pdm.fasta ../nextflu-cdc-fra/augur/data/")
+os.system("cp data/vic.fasta ../nextflu-cdc-fra/augur/data/")
+os.system("cp data/yam.fasta ../nextflu-cdc-fra/augur/data/")
+
+# Download public titers from database
+os.system("python tdb/download.py -db tdb -v flu --ftype augur --subtype h3n2 --select assay_type:hi")
+os.system("python tdb/download.py -db tdb -v flu --ftype augur --subtype h1n1pdm --select assay_type:hi")
+os.system("python tdb/download.py -db tdb -v flu --ftype augur --subtype vic --select assay_type:hi")
+os.system("python tdb/download.py -db tdb -v flu --ftype augur --subtype yam --select assay_type:hi")
 
 # Copy titer tables to nextflu directory
 os.system("cp data/h3n2_hi_strains.tsv ../nextflu/augur/data/")
@@ -35,3 +48,35 @@ os.system("cp data/vic_hi_strains.tsv ../nextflu/augur/data/")
 os.system("cp data/vic_hi_titers.tsv ../nextflu/augur/data/")
 os.system("cp data/yam_hi_strains.tsv ../nextflu/augur/data/")
 os.system("cp data/yam_hi_titers.tsv ../nextflu/augur/data/")
+
+# Download CDC HI titers from database
+os.system("python tdb/download.py -db cdc_tdb -v flu --ftype augur --subtype h3n2 --select assay_type:hi")
+os.system("python tdb/download.py -db cdc_tdb -v flu --ftype augur --subtype h1n1pdm --select assay_type:hi")
+os.system("python tdb/download.py -db cdc_tdb -v flu --ftype augur --subtype vic --select assay_type:hi")
+os.system("python tdb/download.py -db cdc_tdb -v flu --ftype augur --subtype yam --select assay_type:hi")
+
+# Copy titers to nextflu-cdc directory
+os.system("cp data/h3n2_hi_strains.tsv ../nextflu-cdc/augur/data/")
+os.system("cp data/h3n2_hi_titers.tsv ../nextflu-cdc/augur/data/")
+os.system("cp data/h1n1pdm_hi_strains.tsv ../nextflu-cdc/augur/data/")
+os.system("cp data/h1n1pdm_hi_titers.tsv ../nextflu-cdc/augur/data/")
+os.system("cp data/vic_hi_strains.tsv ../nextflu-cdc/augur/data/")
+os.system("cp data/vic_hi_titers.tsv ../nextflu-cdc/augur/data/")
+os.system("cp data/yam_hi_strains.tsv ../nextflu-cdc/augur/data/")
+os.system("cp data/yam_hi_titers.tsv ../nextflu-cdc/augur/data/")
+
+# Download CDC FRA titers from database
+os.system("python tdb/download.py -db cdc_tdb -v flu --ftype augur --subtype h3n2 --select assay_type:fra")
+os.system("python tdb/download.py -db cdc_tdb -v flu --ftype augur --subtype h1n1pdm --select assay_type:fra")
+os.system("python tdb/download.py -db cdc_tdb -v flu --ftype augur --subtype vic --select assay_type:fra")
+os.system("python tdb/download.py -db cdc_tdb -v flu --ftype augur --subtype yam --select assay_type:fra")
+
+# Copy titers to nextflu-cdc-fra directory
+os.system("cp data/h3n2_hi_strains.tsv ../nextflu-cdc-fra/augur/data/")
+os.system("cp data/h3n2_hi_titers.tsv ../nextflu-cdc-fra/augur/data/")
+os.system("cp data/h1n1pdm_hi_strains.tsv ../nextflu-cdc-fra/augur/data/")
+os.system("cp data/h1n1pdm_hi_titers.tsv ../nextflu-cdc-fra/augur/data/")
+os.system("cp data/vic_hi_strains.tsv ../nextflu-cdc-fra/augur/data/")
+os.system("cp data/vic_hi_titers.tsv ../nextflu-cdc-fra/augur/data/")
+os.system("cp data/yam_hi_strains.tsv ../nextflu-cdc-fra/augur/data/")
+os.system("cp data/yam_hi_titers.tsv ../nextflu-cdc-fra/augur/data/")

--- a/tdb/cdc_upload.py
+++ b/tdb/cdc_upload.py
@@ -52,7 +52,8 @@ class cdc_upload(upload):
             self.test_location(meas['virus_strain'])
             self.test_location(meas['serum_strain'])
             self.add_attributes(meas, **kwargs)
-            self.format_subtype(meas)            
+            self.format_subtype(meas)
+            self.format_assay_type(meas)                     
             meas['date'] = meas['assay_date']
             self.format_date(meas)
             self.format_passage(meas, 'serum_antigen_passage', 'serum_passage_category')

--- a/tdb/download.py
+++ b/tdb/download.py
@@ -97,7 +97,7 @@ class download(object):
             handle.close()
             print("Wrote to " + fname)
 
-    def write_text(self, measurements, fname, text_fields=['virus_strain', 'serum_strain', 'serum_id', 'source', 'titer']):
+    def write_text(self, measurements, fname, text_fields=['virus_strain', 'serum_strain', 'serum_id', 'source', 'titer', 'assay_type']):
         try:
             handle = open(fname, 'w')
         except IOError:

--- a/tdb/elife_upload.py
+++ b/tdb/elife_upload.py
@@ -49,6 +49,8 @@ class elife_upload(upload):
             self.test_location(meas['virus_strain'])
             self.test_location(meas['serum_strain'])
             self.add_attributes(meas, **kwargs)
+            self.format_subtype(meas)
+            self.format_assay_type(meas)                
             self.format_date(meas)
             meas['assay_date'] = "XXXX-XX-XX"
             self.format_passage(meas, 'serum_passage', 'serum_passage_category')

--- a/tdb/nimr_upload.py
+++ b/tdb/nimr_upload.py
@@ -33,6 +33,8 @@ class nimr_upload(upload):
             self.test_location(meas['virus_strain'])
             self.test_location(meas['serum_strain'])
             self.add_attributes(meas, **kwargs)
+            self.format_subtype(meas)
+            self.format_assay_type(meas)                
             self.format_date(meas)
             if meas['assay_date'] != None: self.assay_date = meas['assay_date']
             self.format_passages(meas)

--- a/tdb/upload.py
+++ b/tdb/upload.py
@@ -99,6 +99,7 @@ class upload(parse, flu_upload):
             self.test_location(meas['serum_strain'])
             self.add_attributes(meas, **kwargs)
             self.format_subtype(meas)
+            self.format_assay_type(meas)
             self.format_date(meas)
             self.format_passage(meas, 'serum_passage', 'serum_passage_category')
             self.format_passage(meas, 'virus_passage', 'virus_passage_category')
@@ -344,6 +345,18 @@ class upload(parse, flu_upload):
                 meas['subtype'] = 'yam'
         else:
             meas['subtype'] = None
+
+    def format_assay_type(self, meas):
+        '''
+        Format assay_type attribute
+        '''
+        if 'assay_type' in meas:
+            if meas['assay_type'] == 'HI':
+                meas['assay_type'] = 'hi'
+            elif meas['assay_type'] == 'FRA':
+                meas['assay_type'] = 'fra'
+        else:
+            meas['assay_type'] = None
 
     def format_serum_sample(self,meas):
         '''


### PR DESCRIPTION
`--select` and `--present` were already in `tdb/download.py`. This just makes `--select assay_type:hi` function appropriately. It also pads out `download_all` to download separate datasets to different directories.

Fixes #47.