### PR TITLE
Add script to concatenate all titers to one file tracking source/passage

### DIFF
--- a/tdb/concatenate.py
+++ b/tdb/concatenate.py
@@ -1,4 +1,5 @@
 import argparse
+import sys
 
 parser = argparse.ArgumentParser()
 parser.add_argument('files', nargs='+', default=[], help="tsvs that will be concatenated")
@@ -6,7 +7,7 @@ parser.add_argument('files', nargs='+', default=[], help="tsvs that will be conc
 def concat(files):
     for filename in files:
 
-        print "Concatenating and annotating %s." % (filename)
+        sys.stderr.write("Concatenating and annotating %s." % (filename))
 
         if "cdc" in filename.lower():
             source = "cdc"

--- a/tdb/concatenate.py
+++ b/tdb/concatenate.py
@@ -1,36 +1,33 @@
 import argparse
 
 parser = argparse.ArgumentParser()
-parser.add_argument('-f', '--files', nargs='*', default=[], help="tsvs that will be concatenated")
-parser.add_argument('-o', '--output', type=str, default="data/titers_complete.tsv")
+parser.add_argument('files', nargs='+', default=[], help="tsvs that will be concatenated")
 
-def concat(files,out):
-    with open(out, 'w') as o:
-        for filename in files:
+def concat(files):
+    for filename in files:
 
-            print "Concatenating and annotating %s into %s." % (filename, out)
+        print "Concatenating and annotating %s." % (filename)
 
-            if "cdc" in filename.lower():
-                source = "cdc"
-            elif "crick" in filename.lower():
-                source = "crick"
-            else:
-                source = "none"
+        if "cdc" in filename.lower():
+            source = "cdc"
+        elif "crick" in filename.lower():
+            source = "crick"
+        else:
+            source = "unknown"
 
-            if "egg" in filename.lower():
-                passage = "egg"
-            elif "cell" in filename.lower():
-                passage = "egg"
-            else:
-                passage = "none"
+        if "egg" in filename.lower():
+            passage = "egg"
+        elif "cell" in filename.lower():
+            passage = "cell"
+        else:
+            passage = "none"
 
-            with open(filename, 'r') as f:
-                for line in f.readlines():
-                    print line
-                    line = line.strip()
-                    l = "%s\t%s\t%s\n" % (line, source, passage)
-                    o.write(l)
+        with open(filename, 'r') as f:
+            for line in f.readlines():
+                line = line.strip()
+                l = "%s\t%s\t%s" % (line, source, passage)
+                print l
 
 if __name__=="__main__":
     args = parser.parse_args()
-    concat(args.files, args.output)
+    concat(args.files)

--- a/tdb/concatenate.py
+++ b/tdb/concatenate.py
@@ -1,0 +1,36 @@
+import argparse
+
+parser = argparse.ArgumentParser()
+parser.add_argument('-f', '--files', nargs='*', default=[], help="tsvs that will be concatenated")
+parser.add_argument('-o', '--output', type=str, default="data/titers_complete.tsv")
+
+def concat(files,out):
+    with open(out, 'w') as o:
+        for filename in files:
+
+            print "Concatenating and annotating %s into %s." % (filename, out)
+
+            if "cdc" in filename.lower():
+                source = "cdc"
+            elif "crick" in filename.lower():
+                source = "crick"
+            else:
+                source = "none"
+
+            if "egg" in filename.lower():
+                passage = "egg"
+            elif "cell" in filename.lower():
+                passage = "egg"
+            else:
+                passage = "none"
+
+            with open(filename, 'r') as f:
+                for line in f.readlines():
+                    print line
+                    line = line.strip()
+                    l = "%s\t%s\t%s\n" % (line, source, passage)
+                    o.write(l)
+
+if __name__=="__main__":
+    args = parser.parse_args()
+    concat(args.files, args.output)

--- a/tdb/concatenate.py
+++ b/tdb/concatenate.py
@@ -1,13 +1,10 @@
 import argparse
-import sys
 
 parser = argparse.ArgumentParser()
 parser.add_argument('files', nargs='+', default=[], help="tsvs that will be concatenated")
 
 def concat(files):
     for filename in files:
-
-        sys.stderr.write("Concatenating and annotating %s." % (filename))
 
         if "cdc" in filename.lower():
             source = "cdc"


### PR DESCRIPTION
This PR contains a script that will take a set of titer tsvs downloaded from fauna and concatenates them to one master file. Source/passage information is read from file names and added to each entry.
Fixes #76