### PR TITLE
vdb/download.py: Let --fasta_fields take multiple values

### DIFF
--- a/vdb/download.py
+++ b/vdb/download.py
@@ -18,7 +18,7 @@ def get_parser():
     parser.add_argument('--ftype', default='fasta', help="output file format, default \"fasta\", other options are \"json\" and \"tsv\"")
     parser.add_argument('--fstem', help="default output file name is \"VirusName_Year_Month_Date\"")
     parser.add_argument('--path', default='data', help="path to dump output files to")
-    parser.add_argument('--fasta_fields', default=['strain', 'virus', 'accession', 'collection_date', 'region', 'country', 'division', 'location', 'source', 'locus', 'authors'], help="fasta fields for output fasta")
+    parser.add_argument('--fasta_fields', nargs='+', default=['strain', 'virus', 'accession', 'collection_date', 'region', 'country', 'division', 'location', 'source', 'locus', 'authors'], help="fasta fields for output fasta")
 
     parser.add_argument('--public_only', action="store_true", help="include to subset public sequences")
     parser.add_argument('--select', nargs='+', type=str, default=[], help="Select specific fields ie \'--select field1:value1 field2:value1,value2\'")


### PR DESCRIPTION
Otherwise it's not possible to specify a useful set of fields on the
command line.  This hasn't been an issue since currently all the
vdb/*_download.py scripts overwrite any passed value with a hardcoded
list of fields.  For a pathogen build system, however, it's useful to
specify these on the command line.