### PR TITLE
Fix parsing of VIDRL fluB tables

### DIFF
--- a/source-data/flu_fix_location_label.tsv
+++ b/source-data/flu_fix_location_label.tsv
@@ -586,6 +586,7 @@ Moscowv	Moscow
 Novgorod	NizhnyNovgorod
 NovgorogVelikiy	VelikyNovgorod
 NNovgorod	NizhnyNovgorod
+NizniyNovgorod	NizhnyNovgorod
 Nizhni Novgorod	NizhnyNovgorod
 NizhniiNovgorod	NizhnyNovgorod
 NizhniyNovgorod	NizhnyNovgorod

--- a/source-data/geo_synonyms.tsv
+++ b/source-data/geo_synonyms.tsv
@@ -1832,6 +1832,7 @@ Russia	Russia	Russia	Russia
 Adygea	Russia	Adygea	Adygea
 Alania	Russia	OssetiaAlania	Alania
 Anadyr	Russia	Chukotka	Anadyr
+Anapa	Russia	KrasnodarKrai	Anapa	Anapa
 Arkhangelsk	Russia	Arkhangelsk	Arkhangelsk
 Astrakhan	Russia	Astrakhan	Astrakhan
 Barnaul	Russia	AltaiKrai	Barnaul
@@ -1857,6 +1858,7 @@ Karasuk	Russia	Novosibirsk	Karasuk
 Kazan	Russia	Tatarstan	Kazan
 Kemerovo	Russia	Kemerovo	Kemerovo
 Khabarovsk	Russia	Khabarovsk	Khabarovsk
+Khakassia	Russia	Khakassia	Khakassia
 Kirov	Russia	Kirov	Kirov
 KhantyMansia	Russia	KhantyMansia	KhantyMansia
 Koltsovo	Russia	Novosibirsk	Koltsovo

--- a/tdb/upload_all.py
+++ b/tdb/upload_all.py
@@ -79,7 +79,7 @@ def upload_elife(database, elife_path, subtype):
 
 def upload_vidrl(database, subtypes):
     with open('data/vidrl_fail_log.txt', 'w') as o:
-        base_path = '../VIDRL-Melbourne-WHO-CC/raw-data/'
+        base_path = '../../fludata/VIDRL-Melbourne-WHO-CC/raw-data/'
         dir_paths = []
         subtype_to_paths = {
             "h3n2": ["A/H3N2/HI", "A/H3N2/FRA"],

--- a/tdb/upload_all.py
+++ b/tdb/upload_all.py
@@ -154,7 +154,7 @@ if __name__=="__main__":
         params.subtypes = ['h3n2', 'h1n1pdm', 'vic', 'yam']
 
     if params.sources is None:
-        params.sources = ['elife', 'nimr', 'cdc']
+        params.sources = ['elife', 'nimr', 'cdc', 'vidrl']
 
     for source in params.sources:
         if source == "cdc":

--- a/tdb/vidrl_upload.py
+++ b/tdb/vidrl_upload.py
@@ -79,7 +79,7 @@ def parse_vidrl_matrix_to_tsv(fname, original_path, assay_type):
         print("assay_type: " + assay_type)
         if assay_type == "hi":
             start_row = 12
-            start_col = 7
+            start_col = 5 # Changed from 7 to 5 for VIC/YAM tables -BP
             end_col = 15
             virus_strain_col_index = 2
             virus_passage_col_index = 16
@@ -90,8 +90,8 @@ def parse_vidrl_matrix_to_tsv(fname, original_path, assay_type):
             virus_strain_col_index = 2
             virus_passage_col_index = 14
             # some FRA tables have 10 sera, some have 11, some have 9
-            check_cell_10th_sera = mat[7][13]
-            check_cell_11th_sera = mat[7][14]
+            check_cell_10th_sera = mat[start_col][13]
+            check_cell_11th_sera = mat[start_col][14]
             if check_cell_10th_sera == '':
                 virus_passage_col_index = 13
             elif check_cell_10th_sera != '' and check_cell_11th_sera == '':

--- a/tdb/vidrl_upload.py
+++ b/tdb/vidrl_upload.py
@@ -10,7 +10,7 @@ sys.path.append('')  # need to import from base
 from base.rethink_io import rethink_io
 from vdb.flu_upload import flu_upload
 import logging
-logger = logging.getLogger()
+# logger = logging.getLogger()
 
 parser.add_argument('--assay_type', default='hi')
 
@@ -28,7 +28,7 @@ def read_vidrl(path, fstem, assay_type):
         fname = "data/tmp/%s.csv"%(fstem)
         parse_vidrl_matrix_to_tsv(fname, path, assay_type)
     else:
-        logger.critical("Unable to recognize file extension of {}/{}".format(path,fstem))
+        # logger.critical("Unable to recognize file extension of {}/{}".format(path,fstem))
         sys.exit()
 
 def convert_xls_to_csv(path, fstem, ind):

--- a/tdb/vidrl_upload.py
+++ b/tdb/vidrl_upload.py
@@ -152,6 +152,9 @@ if __name__=="__main__":
     args = parser.parse_args()
     if args.path is None:
         args.path = "data/"
+    else:
+        if not args.path.endswith('/'):
+            args.path = args.path + '/'
     if args.database is None:
         args.database = "vidrl_tdb"
     if not os.path.isdir(args.path):

--- a/tdb/vidrl_upload.py
+++ b/tdb/vidrl_upload.py
@@ -100,21 +100,23 @@ def parse_vidrl_matrix_to_tsv(fname, original_path, assay_type):
                 virus_passage_col_index = 15
 
         # some tables are do not begin where we think they do
-        check_cell = mat[10][2]
-        if check_cell == "Reference Antigens":
-            for i in range(start_row, len(mat)):
-                for j in range(start_col, end_col):
-                    virus_strain = mat[i][virus_strain_col_index]
-                    serum_strain = mat[10][j]
-                    serum_id = mat[8][j]
-                    titer = mat[i][j]
-                    source = "vidrl_%s"%(src_id)
-                    virus_passage = mat[i][virus_passage_col_index]
-                    virus_passage_category = ''
-                    serum_passage = mat[9][j]
-                    serum_passage_category = ''
-                    line = "%s\n" % ("\t".join([ virus_strain, serum_strain, serum_id, titer, source, virus_passage, virus_passage_category, serum_passage, serum_passage_category, assay_type]))
-                    outfile.write(line)
+        # add possible starting locations
+        possible_starts = [mat[10][2], mat[13][0]]
+        for check_cell in possible_starts:
+            if check_cell == "Reference Antigens":
+                for i in range(start_row, len(mat)):
+                    for j in range(start_col, end_col):
+                        virus_strain = mat[i][virus_strain_col_index]
+                        serum_strain = mat[10][j]
+                        serum_id = mat[8][j]
+                        titer = mat[i][j]
+                        source = "vidrl_%s"%(src_id)
+                        virus_passage = mat[i][virus_passage_col_index]
+                        virus_passage_category = ''
+                        serum_passage = mat[9][j]
+                        serum_passage_category = ''
+                        line = "%s\n" % ("\t".join([ virus_strain, serum_strain, serum_id, titer, source, virus_passage, virus_passage_category, serum_passage, serum_passage_category, assay_type]))
+                        outfile.write(line)
 
 # def determine_initial_indices(path, fstem):
 #     import xlrd


### PR DESCRIPTION
Vic and Yam tables had been failing to upload because the parser was looking for the text "Reference Antigens" in a particular, hard-coded cell of the tables. The formatting of the fluB tables was slightly different, so they were failing that check. This PR fixes the issue by adding both cases, and trying the fluB case after the fluA case. Additionally, adds some minor bugfixes that were discovered while trying to fix this error.