### PR TITLE
Fix imports from parent modules in vdb and tdb for python 3

### DIFF
--- a/tdb/download.py
+++ b/tdb/download.py
@@ -1,6 +1,8 @@
 import os, json, datetime, sys, time
 import rethinkdb as r
-sys.path.append('')  # need to import from base
+
+# Enable import from modules in parent directory.
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from base.rethink_io import rethink_io
 from vdb.download import download as vdb_download
 

--- a/vdb/download.py
+++ b/vdb/download.py
@@ -3,7 +3,8 @@ import rethinkdb as r
 from Bio import SeqIO
 import numpy as np
 
-sys.path.append('')  # need to import from base
+# Enable import from modules in parent directory.
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from base.rethink_io import rethink_io
 
 


### PR DESCRIPTION
The original fix for importing from parent modules in python 2 did not work for
python 3. The ideal solution would be to reorganize fauna to avoid this type of
import, but this commit implements a short-term solution that works in both
python 2 and 3 by prepending the fauna directory to the python path.