### PR TITLE
Move date selection function

### DIFF
--- a/vdb/download.py
+++ b/vdb/download.py
@@ -7,6 +7,22 @@ import numpy as np
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from base.rethink_io import rethink_io
 
+def rethinkdb_date_greater(greater_date, comparison_date, relaxed_interval):
+    return r.branch(r.lt(greater_date[0], comparison_date[0]),
+        False,
+        r.eq(greater_date[0], comparison_date[0]),
+        r.branch(r.eq(greater_date[1], 'XX').or_(r.eq(comparison_date[1],'XX')),
+            relaxed_interval,
+            r.lt(greater_date[1], comparison_date[1]),
+            False,
+            r.eq(greater_date[1], comparison_date[1]),
+            r.branch(r.eq(greater_date[2], 'XX').or_(r.eq(comparison_date[2],'XX')),
+                relaxed_interval,
+                r.lt(greater_date[2], comparison_date[2]),
+                False,
+                True),
+            True),
+        True)
 
 def get_parser():
     import argparse
@@ -319,20 +335,3 @@ if __name__=="__main__":
         os.makedirs(args.path)
     connVDB = download(**args.__dict__)
     connVDB.download(**args.__dict__)
-
-def rethinkdb_date_greater(greater_date, comparison_date, relaxed_interval):
-    return r.branch(r.lt(greater_date[0], comparison_date[0]),
-        False,
-        r.eq(greater_date[0], comparison_date[0]),
-        r.branch(r.eq(greater_date[1], 'XX').or_(r.eq(comparison_date[1],'XX')),
-            relaxed_interval,
-            r.lt(greater_date[1], comparison_date[1]),
-            False,
-            r.eq(greater_date[1], comparison_date[1]),
-            r.branch(r.eq(greater_date[2], 'XX').or_(r.eq(comparison_date[2],'XX')),
-                relaxed_interval,
-                r.lt(greater_date[2], comparison_date[2]),
-                False,
-                True),
-            True),
-        True)


### PR DESCRIPTION
This PR moves the function `rethinkdb_date_greater` from the end of the `vdb/download.py` to the beginning, so that it is in scope when the download is called. 

This fixes an error when the `--interval` flag was used for virus downloads in which `rethinkdb_date_greater` could not be found by `add_intervals_command`.

@huddlej would you mind taking a look at this just to let me know if this has been moved to the most appropriate location? The (previously broken) command that I have been using to run is:

```
python3 vdb/download.py --database vdb \
     --virus flu \
     --fasta_fields strain virus accession collection_date region country division \
           location passage_category submitting_lab age gender \
     --resolve_method split_passage \
     --select locus:na lineage:seasonal_h3n2 \
     --interval collection_date:2016-03-30,2018-04-31 \
     --path data \
     --fstem h3n2_na
```