### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/base/rethink_interact.py
+++ b/base/rethink_interact.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os, shutil, sys, datetime, re, subprocess, json
 import rethinkdb as r
 import boto3
@@ -71,7 +72,7 @@ class rethink_interact(object):
             command = ['rethinkdb', 'dump', '-e', database + '.' + dump_table, '-f', dump_file]
         try:
             with open(os.devnull, 'wb') as devnull:
-                print " ".join(command)
+                print(" ".join(command))
                 subprocess.check_call(command, stdout=devnull, stderr=subprocess.STDOUT, shell=True)
         except:
             raise Exception("Couldn't dump tar file, make sure " + dump_file + " doesn't exist")

--- a/download_all.py
+++ b/download_all.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Simple script to run required operations to
 # 1. Download FASTAs from database
 # 2. Copy FASTAs to nextflu directory
@@ -31,7 +32,7 @@ def concatenate_titers(params, passage, assay):
         if len(hi_titers) > 0:
             with open(out, 'w+') as f:
                 call = ['cat'] + hi_titers
-                print call
+                print(call)
                 subprocess.call(call, stdout=f)
     for lineage in params.flu_lineages:
         out = 'data/%s_public_%s_%s_titers.tsv'%(lineage, assay, passage)
@@ -43,7 +44,7 @@ def concatenate_titers(params, passage, assay):
         if len(hi_titers) > 0:
             with open(out, 'w+') as f:
                 call = ['cat'] + hi_titers
-                print call
+                print(call)
                 subprocess.call(call, stdout=f)
 
 if __name__=="__main__":

--- a/tdb/concatenate.py
+++ b/tdb/concatenate.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import argparse
 
 parser = argparse.ArgumentParser()
@@ -24,7 +25,7 @@ def concat(files):
             for line in f.readlines():
                 line = line.strip()
                 l = "%s\t%s\t%s" % (line, source, passage)
-                print l
+                print(l)
 
 if __name__=="__main__":
     args = parser.parse_args()

--- a/tdb/crick_upload.py
+++ b/tdb/crick_upload.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os, re, time, datetime, csv, sys, json
 from upload import upload
 import rethinkdb as r
@@ -145,9 +146,9 @@ if __name__=="__main__":
             print("Subtype: {}".format(subtype))
             print("Sheet: {}".format(sheet))
             command = "python tdb/elife_upload.py -db " + args.database +  " --subtype " + subtype + " --path ../../fludata/Crick-London-WHO-CC/processed-data/tsv/ --fstem " + sheet + " --preview"
-            print command
+            print(command)
             subprocess.call(command, shell=True)
         else:
             command = "python tdb/elife_upload.py -db " + args.database +  " --subtype " + subtype + " --path ../../fludata/Crick-London-WHO-CC/processed-data/tsv/ --fstem " + sheet
-            print command
+            print(command)
             subprocess.call(command, shell=True)

--- a/tdb/niid_upload.py
+++ b/tdb/niid_upload.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os, re, time, datetime, csv, sys, json
 from upload import upload
 import rethinkdb as r
@@ -139,9 +140,9 @@ if __name__=="__main__":
     args.fstem = args.fstem.replace('(','\\(').replace(')','\\)')
     if args.preview:
         command = "python tdb/elife_upload.py -db " + args.database +  " --subtype " + subtype + " --path data/tmp/ --fstem " + args.fstem + " --preview"
-        print command
+        print(command)
         subprocess.call(command, shell=True)
     else:
         command = "python tdb/elife_upload.py -db " + args.database +  " --subtype " + subtype + " --path data/tmp/ --fstem " + args.fstem
-        print command
+        print(command)
         subprocess.call(command, shell=True)

--- a/tdb/upload.py
+++ b/tdb/upload.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os, re, time, datetime, csv, sys, json
 import rethinkdb as r
 import hashlib
@@ -74,7 +75,7 @@ class upload(parse, flu_upload):
         measurements = self.filter(measurements)
         measurements = self.create_index(measurements)
         #self.adjust_tdb_strain_names_from_vdb(measurements)
-        print('Total number of indexes', len(self.indexes), 'Total number of measurements', len(measurements))
+        print(('Total number of indexes', len(self.indexes), 'Total number of measurements', len(measurements)))
         if not preview:
             self.upload_documents(self.table, measurements, index='index', **kwargs)
         else:
@@ -210,7 +211,7 @@ class upload(parse, flu_upload):
         if isinstance(strain, basestring) and "/" in strain:
             location = strain.split('/')[1]
             if self.determine_location(location) is None:
-                print("Couldn't determine location for this strain, consider adding to flu_fix_location_label.tsv", location, strain)
+                print(("Couldn't determine location for this strain, consider adding to flu_fix_location_label.tsv", location, strain))
 
     def add_attributes(self, meas, host, **kwargs):
         '''
@@ -294,7 +295,7 @@ class upload(parse, flu_upload):
                 date = datetime.datetime.strptime(meas['date'], '%b %Y').date()
                 meas['date'] = date.strftime('%Y-%m') + '-XX'
             except:
-                print("Couldn't parse as datetime object", meas['date'], meas['source'])
+                print(("Couldn't parse as datetime object", meas['date'], meas['source']))
                 meas['date'] = None
         elif re.match(r'(\d+)-[a-zA-Z][a-zA-Z][a-zA-Z]', meas['date']):  #12-Jan, 9-Jun
             try:
@@ -304,7 +305,7 @@ class upload(parse, flu_upload):
                 date = datetime.datetime.strptime(meas['date'], '%y-%b').date()
                 meas['date'] = date.strftime('%Y-%m') + '-XX'
             except:
-                print("Couldn't parse as datetime object", meas['date'], meas['source'])
+                print(("Couldn't parse as datetime object", meas['date'], meas['source']))
                 meas['date'] = None
         elif re.match(r'[a-zA-Z][a-zA-Z][a-zA-Z]-(\d+)', meas['date']):  #Nov-09, Jan-2012
             try:
@@ -315,14 +316,14 @@ class upload(parse, flu_upload):
                     date = datetime.datetime.strptime(meas['date'], '%b-%y').date()
                 meas['date'] = date.strftime('%Y-%m') + '-XX'
             except:
-                print("Couldn't parse as datetime object", meas['date'], meas['source'])
+                print(("Couldn't parse as datetime object", meas['date'], meas['source']))
                 meas['date'] = None
         elif meas['date'].lower() == 'unknown' or meas['date'].lower() == 'd/m unknown':
             meas['date'] = None
         elif meas['date'] == '':
             meas['date'] = None
         else:
-            print("Couldn't reformat this date: \'" + meas['date'] + "\'", meas['source'], meas['serum_strain'], meas['virus_strain'])
+            print(("Couldn't reformat this date: \'" + meas['date'] + "\'", meas['source'], meas['serum_strain'], meas['virus_strain']))
             meas['date'] = None
 
         meas['assay_date'] = meas['date']
@@ -338,7 +339,7 @@ class upload(parse, flu_upload):
                 meas['ref'] = False
             else:
                 meas['ref'] = None
-                print("Couldn't parse reference status", meas['ref'])
+                print(("Couldn't parse reference status", meas['ref']))
         else:
             meas['ref'] = None
 
@@ -406,21 +407,21 @@ class upload(parse, flu_upload):
         Filter out viruses without correct dating format or without region specified
         Check  optional and upload attributes
         '''
-        print(len(measurements), " measurements before filtering")
+        print((len(measurements), " measurements before filtering"))
 #       print("Filtering out measurements whose serum strain is not paired with a ref or test virus strain ensuring proper formatting")
 #       measurements = filter(lambda meas: meas['serum_strain'] in self.ref_virus_strains or meas['serum_strain'] in self.test_virus_strains, measurements)
         print("Filtering out measurements missing required fields")
         measurements = filter(lambda meas: self.rethink_io.check_required_attributes(meas, self.upload_fields, self.index_fields, output=True), measurements)
         print("Filtering out measurements with virus, serum strain names or titers not formatted correctly")
         measurements = filter(lambda meas: self.correct_strain_format(meas['virus_strain'], meas['original_virus_strain']) and self.correct_strain_format(meas['serum_strain'], meas['original_serum_strain']) and self.correct_titer_format(meas['titer']), measurements)
-        print(len(measurements), " measurements after filtering")
+        print((len(measurements), " measurements after filtering"))
         return measurements
 
     def correct_titer_format(self, titer):
         if re.match("^[0-9<>.]*$", titer):
             return True
         else:
-            print "Bad titer: {}. Removing.".format(titer)
+            print("Bad titer: {}. Removing.".format(titer))
             return False
 
 if __name__=="__main__":

--- a/tdb/upload.py
+++ b/tdb/upload.py
@@ -75,7 +75,7 @@ class upload(parse, flu_upload):
         measurements = self.filter(measurements)
         measurements = self.create_index(measurements)
         #self.adjust_tdb_strain_names_from_vdb(measurements)
-        print(('Total number of indexes', len(self.indexes), 'Total number of measurements', len(measurements)))
+        print('Total number of indexes', len(self.indexes), 'Total number of measurements', len(measurements))
         if not preview:
             self.upload_documents(self.table, measurements, index='index', **kwargs)
         else:
@@ -211,7 +211,7 @@ class upload(parse, flu_upload):
         if isinstance(strain, basestring) and "/" in strain:
             location = strain.split('/')[1]
             if self.determine_location(location) is None:
-                print(("Couldn't determine location for this strain, consider adding to flu_fix_location_label.tsv", location, strain))
+                print("Couldn't determine location for this strain, consider adding to flu_fix_location_label.tsv", location, strain)
 
     def add_attributes(self, meas, host, **kwargs):
         '''
@@ -295,7 +295,7 @@ class upload(parse, flu_upload):
                 date = datetime.datetime.strptime(meas['date'], '%b %Y').date()
                 meas['date'] = date.strftime('%Y-%m') + '-XX'
             except:
-                print(("Couldn't parse as datetime object", meas['date'], meas['source']))
+                print("Couldn't parse as datetime object", meas['date'], meas['source'])
                 meas['date'] = None
         elif re.match(r'(\d+)-[a-zA-Z][a-zA-Z][a-zA-Z]', meas['date']):  #12-Jan, 9-Jun
             try:
@@ -305,7 +305,7 @@ class upload(parse, flu_upload):
                 date = datetime.datetime.strptime(meas['date'], '%y-%b').date()
                 meas['date'] = date.strftime('%Y-%m') + '-XX'
             except:
-                print(("Couldn't parse as datetime object", meas['date'], meas['source']))
+                print("Couldn't parse as datetime object", meas['date'], meas['source'])
                 meas['date'] = None
         elif re.match(r'[a-zA-Z][a-zA-Z][a-zA-Z]-(\d+)', meas['date']):  #Nov-09, Jan-2012
             try:
@@ -316,14 +316,14 @@ class upload(parse, flu_upload):
                     date = datetime.datetime.strptime(meas['date'], '%b-%y').date()
                 meas['date'] = date.strftime('%Y-%m') + '-XX'
             except:
-                print(("Couldn't parse as datetime object", meas['date'], meas['source']))
+                print("Couldn't parse as datetime object", meas['date'], meas['source'])
                 meas['date'] = None
         elif meas['date'].lower() == 'unknown' or meas['date'].lower() == 'd/m unknown':
             meas['date'] = None
         elif meas['date'] == '':
             meas['date'] = None
         else:
-            print(("Couldn't reformat this date: \'" + meas['date'] + "\'", meas['source'], meas['serum_strain'], meas['virus_strain']))
+            print("Couldn't reformat this date: \'" + meas['date'] + "\'", meas['source'], meas['serum_strain'], meas['virus_strain'])
             meas['date'] = None
 
         meas['assay_date'] = meas['date']
@@ -339,7 +339,7 @@ class upload(parse, flu_upload):
                 meas['ref'] = False
             else:
                 meas['ref'] = None
-                print(("Couldn't parse reference status", meas['ref']))
+                print("Couldn't parse reference status", meas['ref'])
         else:
             meas['ref'] = None
 
@@ -407,14 +407,14 @@ class upload(parse, flu_upload):
         Filter out viruses without correct dating format or without region specified
         Check  optional and upload attributes
         '''
-        print((len(measurements), " measurements before filtering"))
+        print(len(measurements), " measurements before filtering")
 #       print("Filtering out measurements whose serum strain is not paired with a ref or test virus strain ensuring proper formatting")
 #       measurements = filter(lambda meas: meas['serum_strain'] in self.ref_virus_strains or meas['serum_strain'] in self.test_virus_strains, measurements)
         print("Filtering out measurements missing required fields")
         measurements = filter(lambda meas: self.rethink_io.check_required_attributes(meas, self.upload_fields, self.index_fields, output=True), measurements)
         print("Filtering out measurements with virus, serum strain names or titers not formatted correctly")
         measurements = filter(lambda meas: self.correct_strain_format(meas['virus_strain'], meas['original_virus_strain']) and self.correct_strain_format(meas['serum_strain'], meas['original_serum_strain']) and self.correct_titer_format(meas['titer']), measurements)
-        print((len(measurements), " measurements after filtering"))
+        print(len(measurements), " measurements after filtering")
         return measurements
 
     def correct_titer_format(self, titer):

--- a/tdb/upload_all.py
+++ b/tdb/upload_all.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import argparse
 import subprocess
 import os, sys
@@ -21,19 +22,19 @@ def upload_nimr(database, nimr_path, subtype):
     of virus (H3N2, H1N1pdm, etc.).
     '''
     path = nimr_path + subtype + "/"
-    print "Uploading NIMR data for subtype", subtype, "contained in directory", path + "."
+    print("Uploading NIMR data for subtype", subtype, "contained in directory", path + ".")
 
     for fname in os.listdir(path):
         if fname[0] != '.':
             fpath = path + fname
             fstem = fname[:-4]
-            print "Uploading " + fname
+            print("Uploading " + fname)
             command = "python tdb/nimr_upload.py -db " + database + " --subtype " + subtype + " --ftype tables --path " + path + " --fstem " + fstem
-            print "Running with: " + command
+            print("Running with: " + command)
             subprocess.call(command, shell=True)
-            print "Done with", fname + "."
+            print("Done with", fname + ".")
 
-    print "Done uploading NIMR documents."
+    print("Done uploading NIMR documents.")
 
 def upload_cdc(database, cdc_path):
     '''
@@ -42,19 +43,19 @@ def upload_cdc(database, cdc_path):
     There are multiple subtypes within a file.
     '''
     path = cdc_path
-    print "Uploading CDC data contained in directory", path + "."
+    print("Uploading CDC data contained in directory", path + ".")
 
     for fname in os.listdir(path):
         if fname[0] != '.':
             fpath = path + fname
             fstem = fname[:-4]
-            print "Uploading " + fname
+            print("Uploading " + fname)
             command = "python tdb/cdc_upload.py -db cdc_tdb --path " + path + " --fstem " + fstem
-            print "Running with: " + command
+            print("Running with: " + command)
             subprocess.call(command, shell=True)
-            print "Done with", fname + "."
+            print("Done with", fname + ".")
 
-    print "Done uploading CDC documents."
+    print("Done uploading CDC documents.")
 
 def upload_elife(database, elife_path, subtype):
     '''
@@ -63,19 +64,19 @@ def upload_elife(database, elife_path, subtype):
     of virus (H3N2, H1N1pdm, etc.).
     '''
     path = elife_path + subtype + "/"
-    print "Uploading eLife data for subtype", subtype, "contained in directory", path + "."
+    print("Uploading eLife data for subtype", subtype, "contained in directory", path + ".")
 
     for fname in os.listdir(path):
         if fname[0] != '.':
             fpath = path + fname
             fstem = fname[:-4]
-            print "Uploading " + fname
+            print("Uploading " + fname)
             command = "python tdb/elife_upload.py -db " + database + " --subtype " + subtype + " --path " + path + " --fstem " + fstem
-            print "Running with: " + command
+            print("Running with: " + command)
             subprocess.call(command, shell=True)
-            print "Done with", fname + "."
+            print("Done with", fname + ".")
 
-    print "Done uploading stored eLife documents."
+    print("Done uploading stored eLife documents.")
 
 def upload_vidrl(database, subtypes):
     with open('data/vidrl_fail_log.txt', 'w') as o:
@@ -98,14 +99,14 @@ def upload_vidrl(database, subtypes):
                     fstem = fname.split('.')[0]
                     if ' ' in fstem:
                         fstem = re.escape(fstem)
-                    print "Uploading " + fname
+                    print("Uploading " + fname)
                     command = "python tdb/vidrl_upload.py -db {} -v flu --subtype {} --assay_type {} --path {} --fstem {} --ftype vidrl".format(database, subtype, assay_type, complete_path, fstem)
-                    print "Running with: " + command
+                    print("Running with: " + command)
                     try:
                         subprocess.call(command, shell=True)
                     except:
                         logger.critical("Couldn't upload {}, please try again.".format(fname))
-                    print "Done with", fname + "."
+                    print("Done with", fname + ".")
 
 def upload_niid(database, subtypes):
     with open('data/niid_fail_log.txt', 'w') as o:
@@ -133,14 +134,14 @@ def upload_niid(database, subtypes):
                     fstem = fstem.replace('(','\\(').replace(')','\\)')
                     if ' ' in fstem:
                         fstem = re.escape(fstem)
-                    print "Uploading " + fname
+                    print("Uploading " + fname)
                     command = "python tdb/niid_upload.py -db {} -v flu --subtype {} --assay_type {} --path {} --fstem {} --ftype niid".format(database, subtype, assay_type, complete_path, fstem)
-                    print "Running with: " + command
+                    print("Running with: " + command)
                     try:
                         subprocess.call(command, shell=True)
                     except:
                         o.writeline("Couldn't upload {}, please try again.".format(infile))
-                    print "Done with", fname + "."
+                    print("Done with", fname + ".")
 
 def upload_crick(database, subtypes):
     with open('data/crick_fail_log.txt', 'w') as o:
@@ -168,14 +169,14 @@ def upload_crick(database, subtypes):
                     fstem = fstem.replace('(','\\(').replace(')','\\)')
                     if ' ' in fstem:
                         fstem = re.escape(fstem)
-                    print "Uploading " + fname
+                    print("Uploading " + fname)
                     command = "python tdb/crick_upload.py -db {} -v flu --subtype {} --assay_type {} --path {} --fstem {} --ftype tables".format(database, subtype, assay_type, complete_path, fstem)
-                    print "Running with: " + command
+                    print("Running with: " + command)
                     try:
                         subprocess.call(command, shell=True)
                     except:
                         o.writeline("Couldn't upload {}, please try again.".format(infile))
-                    print "Done with", fname + "."
+                    print("Done with", fname + ".")
 
 if __name__=="__main__":
     params = parser.parse_args()
@@ -187,7 +188,7 @@ if __name__=="__main__":
     # root_logger.addHandler(ColorizingStreamHandler())
     # logger = logging.getLogger(__name__)
 
-    print "Beginning construction of", params.database + "."
+    print("Beginning construction of", params.database + ".")
 
     if params.subtypes is None:
         params.subtypes = ['h3n2', 'h1n1pdm', 'vic', 'yam']
@@ -212,4 +213,4 @@ if __name__=="__main__":
         if source == "crick":
             upload_crick(params.database, params.subtypes)
 
-    print "Done with all uploads."
+    print("Done with all uploads.")

--- a/tdb/utils/fix_input_file_spaces.py
+++ b/tdb/utils/fix_input_file_spaces.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os, subprocess
 import re
 
@@ -18,7 +19,7 @@ def fix_input_file_spaces():
                         fstem = re.escape(fstem)
                         fname = "{}.{}".format(fstem,fext)
                         command = 'mv {}{} {}{}'.format(complete_path, fname, complete_path, new_fname)
-                        print command
+                        print(command)
                         subprocess.call(command, shell=True)
 
 if __name__=="__main__":

--- a/tdb/vidrl_upload.py
+++ b/tdb/vidrl_upload.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os, re, time, datetime, csv, sys, json, errno
 from upload import upload
 import rethinkdb as r
@@ -151,11 +152,11 @@ if __name__=="__main__":
     if args.subtype:
         if args.preview:
             command = "python tdb/elife_upload.py -db " + args.database +  " --subtype " + args.subtype + " --path data/tmp/ --fstem " + args.fstem + " --preview"
-            print command
+            print(command)
             subprocess.call(command, shell=True)
         else:
             command = "python tdb/elife_upload.py -db " + args.database +  " --subtype " + args.subtype + " --path data/tmp/ --fstem " + args.fstem
-            print command
+            print(command)
             subprocess.call(command, shell=True)
     else:
         print("Subtype needs to be specified with --subtype")


### PR DESCRIPTION
Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.

### Description of proposed changes    
What is the goal of this pull request? What does this pull request change?

### Related issue(s)  
<!-- Start typing the name of a related issue and github will autosuggest the issue number for you -->
Fixes #  
Related to #  

### Testing
What steps should be taken to test the changes you've proposed?  
If you added or changed behavior in the codebase, did you update the tests, or do you need help with this?  

### Thank you for contributing to Nextstrain!
