### PR TITLE
Upgrade to Python 3 and RethinkDB 2.4.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Resulting data and inferences are available live at the website [nextstrain.org]
 
 The fauna database stores viral sequences and serological data in [RethinkDB](RETHINKDB.md). The current database and scripts are designed around influenza, Ebola and Zika viruses, but with the intention of provided a general purpose tool.
 
-_Note: In most cases, it will be easier to pass augur a self-prepared FASTA file than to use fauna with the overhead of launching a RethinkDB instance. If you are new to Nextstrain, we suggest you skip fauna and proceed to directly to augur._
+_Note: In most cases, it will be easier to pass augur a self-prepared FASTA file than to use fauna with the overhead of launching a RethinkDB instance. If you are new to Nextstrain, we suggest you skip fauna and proceed to directly to Augur._
 
 ### vdb
 
@@ -26,7 +26,7 @@ We maintain notes on [supported virus builds](builds/).
 
 ## Install
 
-Clone the repo and load submodules:
+Fauna requires Python 3. Clone the repo and load submodules:
 
     git clone https://github.com/nextstrain/fauna.git
     cd fauna
@@ -34,17 +34,19 @@ Clone the repo and load submodules:
 
 Install Python modules needed to run upload/download scripts:
 
-    python2 -m pip install -r requirements.txt
+    python3 -m pip install -r requirements.txt
 
 Install Chateau Web UI:
 
-    cd chateau 
+    cd chateau
     npm install
 
 Backup and restore functionality requires the rethinkdb command line utility. This can be installed by following instructions [here](http://www.rethinkdb.com/docs/install/). With Homebrew, you can just do:
 
     cd ..
     brew install rethinkdb
+
+Most functions have been converted to work only in Python 3. However particular calls may not have been converted. If you run into a Python 2/3 error please note in an issue.
 
 ## Environment variables
 
@@ -67,6 +69,6 @@ Chateau configurations are stored in [`config.js`](config.js).
 
 ## License and copyright
 
-Copyright 2016-2018 Trevor Bedford.
+Copyright 2016-2020 Trevor Bedford.
 
 Source code to Nextstrain is made available under the terms of the [GNU Affero General Public License](LICENSE.txt) (AGPL). Nextstrain is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.

--- a/RETHINKDB.md
+++ b/RETHINKDB.md
@@ -25,7 +25,7 @@ locally, data will be saved after stopping the server and loaded when rebooting 
 ### Import RethinkDB driver
 
 ```
-import rethinkdb as r
+from rethinkdb import r
 ```
 
 ### Open connection to rethink database

--- a/base/rethink_interact.py
+++ b/base/rethink_interact.py
@@ -71,7 +71,7 @@ class rethink_interact(object):
             command = ['rethinkdb', 'dump', '-e', database + '.' + dump_table, '-f', dump_file]
         try:
             with open(os.devnull, 'wb') as devnull:
-                print " ".join(command)
+                print(" ".join(command))
                 subprocess.check_call(command, stdout=devnull, stderr=subprocess.STDOUT, shell=True)
         except:
             raise Exception("Couldn't dump tar file, make sure " + dump_file + " doesn't exist")

--- a/base/rethink_interact.py
+++ b/base/rethink_interact.py
@@ -1,5 +1,5 @@
 import os, shutil, sys, datetime, re, subprocess, json
-import rethinkdb as r
+from rethinkdb import r
 import boto3
 sys.path.append('')  # need to import from base
 from base.rethink_io import rethink_io

--- a/base/rethink_io.py
+++ b/base/rethink_io.py
@@ -1,5 +1,5 @@
-import rethinkdb as r
 import datetime, os
+from rethinkdb import r
 
 class rethink_io(object):
     def __init__(self, **kwargs):

--- a/builds/AVIAN_FLU.md
+++ b/builds/AVIAN_FLU.md
@@ -16,7 +16,7 @@
     * `DNA Accession no. | Isolate name | Isolate ID | Segment | Passage details/history | Submitting lab`
 2. Move files to `fauna/data` as `gisaid_epiflu.xls` and `gisaid_epiflu.fasta`.
 3. Upload to vdb database
-  * `python2 vdb/avian_flu_upload.py -db vdb -v avian_flu --data_source gisaid --source gisaid --fname gisaid_epiflu`
+  * `python3 vdb/avian_flu_upload.py -db vdb -v avian_flu --data_source gisaid --source gisaid --fname gisaid_epiflu`
   * Recommend running with `--preview` to confirm strain names and locations are correctly parsed before uploading
   	* Can add to [geo_synonyms file](source-data/geo_synonyms.tsv) and [flu_fix_location_label file](source-data/flu_fix_location_label.tsv) to fix some of the formatting.
 
@@ -32,12 +32,12 @@
   * Download "Segment FASTA" as `GenomicFastaResults.fasta`. Select "Custom format", select all and add.
 2. Move file to `fauna/data` as `GenomicFastaResults.fasta`.
 3. Upload to vdb database
-  * `python2 vdb/avian_flu_upload.py -db vdb -v avian_flu --data_source ird --source ird --fname GenomicFastaResults.fasta`
+  * `python3 vdb/avian_flu_upload.py -db vdb -v avian_flu --data_source ird --source ird --fname GenomicFastaResults.fasta`
   * Recommend running with `--preview` to confirm strain names and locations are correctly parsed before uploading
   	* Can add to [geo_synonyms file](source-data/geo_synonyms.tsv) and [flu_fix_location_label file](source-data/flu_fix_location_label.tsv) to fix some of the formatting.
 
 ### Download documents from VDB
 
 ```
-python2 vdb/avian_flu_download.py -db vdb -v avian_flu --select locus:HA subtype:h7n9 --fstem h7n9_ha
+python3 vdb/avian_flu_download.py -db vdb -v avian_flu --select locus:HA subtype:h7n9 --fstem h7n9_ha
 ```

--- a/builds/DENGUE.md
+++ b/builds/DENGUE.md
@@ -6,27 +6,27 @@
 
 1. Download sequences
   * Select genome length >= 5000
-  * Download as Genome Fasta
+  * Download as Genome FASTA
   * Set Custom Format Fields to 0: GenBank Accession, 1: Strain Name, 2: Segment, 3: Date, 4: Host, 5: Country, 6: Subtype, 7: Virus Type
 2. Move downloaded sequences to `fauna/GenomicFastaResults.fasta`
 3. Upload to vdb database
-  * `python2 vdb/dengue_upload.py -db vdb -v dengue --source genbank --locus genome --fname GenomicFastaResults.fasta`
+  * `python3 vdb/dengue_upload.py -db vdb -v dengue --source genbank --locus genome --fname GenomicFastaResults.fasta`
 
 ## Update
 
 * Update citation fields
-  * `python2 vdb/dengue_update.py -db vdb -v dengue --update_citations`
+  * `python3 vdb/dengue_update.py -db vdb -v dengue --update_citations`
   * updates `authors`, `title`, `url`, `journal` and `puburl` fields from genbank files
   * If you get `ERROR: Couldn't connect with entrez, please run again` just run command again    
 
 ## Download sequence documents from VDB
 
-* `python2 vdb/dengue_download.py` # all serotypes together
-* `python2 vdb/dengue_download.py --select serotype:dengue_virus_1` # just serotype 1
-* `python2 vdb/dengue_download.py --select serotype:dengue_virus_2` # just serotype 2
-* `python2 vdb/dengue_download.py --select serotype:dengue_virus_3` # just serotype 3
-* `python2 vdb/dengue_download.py --select serotype:dengue_virus_4` # just serotype 4
+* `python3 vdb/dengue_download.py -v dengue` # all serotypes together
+* `python3 vdb/dengue_download.py -v dengue --select serotype:dengue_virus_1` # just serotype 1
+* `python3 vdb/dengue_download.py -v dengue --select serotype:dengue_virus_2` # just serotype 2
+* `python3 vdb/dengue_download.py -v dengue --select serotype:dengue_virus_3` # just serotype 3
+* `python3 vdb/dengue_download.py -v dengue --select serotype:dengue_virus_4` # just serotype 4
 
 ## Download titer documents from TDB
 
-* `python2 tdb/download.py -db tdb -v dengue --fstem dengue`
+* `python3 tdb/download.py -db tdb -v dengue --fstem dengue`

--- a/builds/FLU.md
+++ b/builds/FLU.md
@@ -14,7 +14,7 @@
     * `DNA Accession no. | Isolate name | Isolate ID | Segment | Passage details/history | Submitting lab`
 2. Move files to `fauna/data` as `gisaid_epiflu.xls` and `gisaid_epiflu.fasta`.
 3. Upload to vdb database
-  * `python2 vdb/flu_upload.py -db vdb -v flu --source gisaid --fname gisaid_epiflu`
+  * `python3 vdb/flu_upload.py -db vdb -v flu --source gisaid --fname gisaid_epiflu`
   * Recommend running with `--preview` to confirm strain names and locations are correctly parsed before uploading
   	* Can add to [geo_synonyms file](source-data/geo_synonyms.tsv), [flu_strain_name_fix file](source-data/flu_strain_name_fix.tsv) and [flu_fix_location_label file](source-data/flu_fix_location_label.tsv) to fix some of the formatting.
 
@@ -23,23 +23,23 @@
 All of these functions are quite slow given they run over ~600k documents. Use sparingly.
 
 * Update genetic grouping fields
-  * `python2 vdb/flu_update.py -db vdb -v flu --update_groupings`
+  * `python3 vdb/flu_update.py -db vdb -v flu --update_groupings`
   * updates `vtype`, `subtype`, `lineage`
 
 * Update locations
-  * `python2 vdb/flu_update.py -db vdb -v flu --update_locations`
+  * `python3 vdb/flu_update.py -db vdb -v flu --update_locations`
   * updates `division`, `country` and `region` from `location`
 
 * Update passage_category fields
-  * `python2 vdb/flu_update.py -db vdb -v flu --update_passage_categories`
+  * `python3 vdb/flu_update.py -db vdb -v flu --update_passage_categories`
   * update `passage_category` based on `passage` field
 
 ### Download documents from VDB
 
-* `python2 vdb/flu_download.py -db vdb -v flu --select locus:HA lineage:seasonal_h3n2 --fstem h3n2`
-* `python2 vdb/flu_download.py -db vdb -v flu --select locus:HA lineage:seasonal_h1n1pdm --fstem h1n1pdm`
-* `python2 vdb/flu_download.py -db vdb -v flu --select locus:HA lineage:seasonal_vic --fstem vic`
-* `python2 vdb/flu_download.py -db vdb -v flu --select locus:HA lineage:seasonal_yam --fstem yam`
+* `python3 vdb/flu_download.py -db vdb -v flu --select locus:HA lineage:seasonal_h3n2 --fstem h3n2`
+* `python3 vdb/flu_download.py -db vdb -v flu --select locus:HA lineage:seasonal_h1n1pdm --fstem h1n1pdm`
+* `python3 vdb/flu_download.py -db vdb -v flu --select locus:HA lineage:seasonal_vic --fstem vic`
+* `python3 vdb/flu_download.py -db vdb -v flu --select locus:HA lineage:seasonal_yam --fstem yam`
 
 ## TDB
 
@@ -50,47 +50,47 @@ All of these functions are quite slow given they run over ~600k documents. Use s
 1. Convert [NIMR report](https://www.crick.ac.uk/research/worldwide-influenza-centre/annual-and-interim-reports/) pdfs to csv files
 2. Move csv files to subtype directory in `fauna/data/`
 3. Upload to tdb database
-  * `python2 tdb/upload.py -db tdb -v flu --subtype h3n2 --ftype flat --fstem h3n2_nimr_titers`
+  * `python3 tdb/upload.py -db tdb -v flu --subtype h3n2 --ftype flat --fstem h3n2_nimr_titers`
   * Recommend running with `--preview` to confirm strain names are correctly parsed before uploading
   	* Can add to [HI_ref_name_abbreviations file](source-data/HI_ref_name_abbreviations.tsv) and [HI_flu_strain_name_fix file](source-data/HI_flu_strain_name_fix.tsv) to fix some strain names.
 
 #### Flat files
 
 1. Move line-list tsv files to `fauna/data/`
-2. Upload to tdb database with `python2 tdb/upload.py -db tdb -v flu --subtype h3n2 --ftype flat --fstem H3N2_HI_titers_upload`
+2. Upload to tdb database with `python3 tdb/upload.py -db tdb -v flu --subtype h3n2 --ftype flat --fstem H3N2_HI_titers_upload`
 
 #### CDC files
 
 1. Move line-list tsv files to `fauna/data/`
-2. Upload HI titers to tdb database with `python2 tdb/cdc_upload.py -db cdc_tdb -v flu --ftype flat --fstem HITest_Oct2019_to_Sep2020_titers`
-3. Upload FRA titers to tdb database with `python2 tdb/cdc_upload.py -db cdc_tdb -v flu --ftype flat --fstem FRA_Oct2019_to_Sep2020_titers`
+2. Upload HI titers to tdb database with `python3 tdb/cdc_upload.py -db cdc_tdb -v flu --ftype flat --fstem HITest_Oct2019_to_Sep2020_titers`
+3. Upload FRA titers to tdb database with `python3 tdb/cdc_upload.py -db cdc_tdb -v flu --ftype flat --fstem FRA_Oct2019_to_Sep2020_titers`
 
 #### Crick files
 
 1. Move Excel documents to `fauna/data/`
-2. Run `python2 tdb/crick_upload.py -db crick_tdb --assay_type hi --fstem H3N2HIs`
-3. Run `python2 tdb/crick_upload.py -db crick_tdb --assay_type fra --fstem H3N2VNs`
-4. Run `python2 tdb/crick_upload.py -db crick_tdb --assay_type hi --fstem H1N1pdm09HIs`
-5. Run `python2 tdb/crick_upload.py -db crick_tdb --assay_type hi --fstem BVicHIs`
-6. Run `python2 tdb/crick_upload.py -db crick_tdb --assay_type hi --fstem BYamHIs`
+2. Run `python3 tdb/crick_upload.py -db crick_tdb --assay_type hi --fstem H3N2HIs`
+3. Run `python3 tdb/crick_upload.py -db crick_tdb --assay_type fra --fstem H3N2VNs`
+4. Run `python3 tdb/crick_upload.py -db crick_tdb --assay_type hi --fstem H1N1pdm09HIs`
+5. Run `python3 tdb/crick_upload.py -db crick_tdb --assay_type hi --fstem BVicHIs`
+6. Run `python3 tdb/crick_upload.py -db crick_tdb --assay_type hi --fstem BYamHIs`
 
 #### NIID files
 
 1. Make sure `NIID-Tokyo-WHO-CC/` is a sister directory to `fauna/`
-2. Upload all titers with `python2 tdb/upload_all.py --sources niid -db niid_tdb`
+2. Upload all titers with `python3 tdb/upload_all.py --sources niid -db niid_tdb`
 
 #### VIDRL files
 
 1. Make sure `VIDRL-Melbourne-WHO-CC/` is a sister directory to `fauna/`
-2. Upload all titers with `python2 tdb/upload_all.py --sources vidrl -db vidrl_tdb`
+2. Upload all titers with `python3 tdb/upload_all.py --sources vidrl -db vidrl_tdb`
 
 ##### VIDRL Flat files
 * These are flat CSV files that should replace the raw Excel tables.
-* Upload with `python2 tdb/vidrl_upload.py -db vidrl_tdb -v flu --subtype <subtype> --path <path> --fstem <fstem> --ftype flat`
+* Upload with `python3 tdb/vidrl_upload.py -db vidrl_tdb -v flu --subtype <subtype> --path <path> --fstem <fstem> --ftype flat`
 
 ### Download documents from TDB
 
-* `python2 tdb/download.py -db tdb -v flu --subtype h3n2`
-* `python2 tdb/download.py -db tdb -v flu --subtype h1n1pdm`
-* `python2 tdb/download.py -db tdb -v flu --subtype vic`
-* `python2 tdb/download.py -db tdb -v flu --subtype yam`
+* `python3 tdb/download.py -db tdb -v flu --subtype h3n2`
+* `python3 tdb/download.py -db tdb -v flu --subtype h1n1pdm`
+* `python3 tdb/download.py -db tdb -v flu --subtype vic`
+* `python3 tdb/download.py -db tdb -v flu --subtype yam`

--- a/builds/MEASLES.md
+++ b/builds/MEASLES.md
@@ -8,8 +8,8 @@
 
 ## Upload to fauna
 
-`python2 vdb/measles_upload.py -db vdb -v measles --ftype accession --source genbank --locus genome --fname sequence.seq`
+`python3 vdb/measles_upload.py -db vdb -v measles --ftype accession --source genbank --locus genome --fname sequence.seq`
 
 ## Download from fauna
 
-`python2 vdb/measles_download.py -db vdb -v measles --fstem measles --resolve_method choose_genbank`
+`python3 vdb/measles_download.py -db vdb -v measles --fstem measles --resolve_method choose_genbank`

--- a/builds/MUMPS.md
+++ b/builds/MUMPS.md
@@ -8,7 +8,7 @@
 
 ## Upload to fauna
 
-`python2 vdb/mumps_upload.py -db vdb -v mumps --ftype accession --source genbank --locus genome --fname sequence.seq`
+`python3 vdb/mumps_upload.py -db vdb -v mumps --ftype accession --source genbank --locus genome --fname sequence.seq`
 
 
 FASTA header field ordering:
@@ -24,35 +24,34 @@ FASTA header field ordering:
 
 _This is not necessary when uploading accessions as we do here._
 This is needed to populate certain attributes such as author & paper title.
-`python2 vdb/mumps_update.py -db vdb -v mumps --update_citations`
+`python3 vdb/mumps_update.py -db vdb -v mumps --update_citations`
 
 ## Download from fauna
 
-`python2 vdb/mumps_download.py -db vdb -v mumps --fstem mumps --resolve_method choose_genbank`
+`python3 vdb/mumps_download.py -db vdb -v mumps --fstem mumps --resolve_method choose_genbank`
 
 ## Upload Broad genomes
 
 Preprocess to fix metadata and header ordering
 
-`python2 vdb/mumps_preprocess_fasta.py --fasta data/muv-nextstrain-20170718.pruned.fasta > data/mumps_broad.fasta`
+`python3 vdb/mumps_preprocess_fasta.py --fasta data/muv-nextstrain-20170718.pruned.fasta > data/mumps_broad.fasta`
 
 Upload to fauna
 
-`python2 vdb/mumps_upload.py -db vdb -v mumps --source broad --locus genome --fname mumps_broad.fasta --authors "Wohl et al" --title "Unpublished"`
+`python3 vdb/mumps_upload.py -db vdb -v mumps --source broad --locus genome --fname mumps_broad.fasta --authors "Wohl et al" --title "Unpublished"`
 
 ## Upload BCCDC genomes
 
 If you have a FASTA file and CSV metadata, this script will help (with minor modifications as needed)
 
-`python2 scripts/mumps.csv-and-fasta-to-vipr-fasta.py data/input.mumps.raw.fasta data/input.mumps.csv data/input.mumps.vipr.fasta`
-
+`python3 scripts/mumps.csv-and-fasta-to-vipr-fasta.py data/input.mumps.raw.fasta data/input.mumps.csv data/input.mumps.vipr.fasta`
 
 Upload to fauna
 
-`python2 vdb/mumps_upload.py -db vdb -v mumps --source bccdc --locus genome --fname mumps.bc.fasta --authors "Gardy et al" --title "Unpublished"`
+`python3 vdb/mumps_upload.py -db vdb -v mumps --source bccdc --locus genome --fname mumps.bc.fasta --authors "Gardy et al" --title "Unpublished"`
 
 ## Upload Fred Hutch genomes
 
 Upload to fauna
 
-`python2 vdb/mumps_upload.py -db vdb -v mumps --source fh --locus genome --fname MuVs-WA0268502_buccal-Washington.USA-16.fasta --authors "Moncla et al" --title "Unpublished"`
+`python3 vdb/mumps_upload.py -db vdb -v mumps --source fh --locus genome --fname MuVs-WA0268502_buccal-Washington.USA-16.fasta --authors "Moncla et al" --title "Unpublished"`

--- a/builds/ZIKA.md
+++ b/builds/ZIKA.md
@@ -2,7 +2,7 @@
 
 ## Download
 
-    python2 vdb/zika_download.py -db vdb -v zika --fstem zika --resolve_method choose_genbank
+    python3 vdb/zika_download.py -db vdb -v zika --fstem zika --resolve_method choose_genbank
 
 ## Upload
 
@@ -14,7 +14,7 @@
   * Set Custom Format Fields to 0: GenBank Accession, 1: Strain Name, 2: Segment, 3: Date, 4: Host, 5: Country, 6: Subtype, 7: Virus Species
 2. Move downloaded sequences to `fauna/data`
 3. Upload to vdb database
-  * `python2 vdb/zika_upload.py -db vdb -v zika --source genbank --locus genome --fname GenomicFastaResults.fasta`
+  * `python3 vdb/zika_upload.py -db vdb -v zika --source genbank --locus genome --fname GenomicFastaResults.fasta`
 
 ### [Fred Hutch sequences](https://github.com/blab/zika-usvi/tree/master/data)
 

--- a/download_all.py
+++ b/download_all.py
@@ -31,7 +31,7 @@ def concatenate_titers(params, passage, assay):
         if len(hi_titers) > 0:
             with open(out, 'w+') as f:
                 call = ['cat'] + hi_titers
-                print call
+                print(call)
                 subprocess.call(call, stdout=f)
     for lineage in params.flu_lineages:
         out = 'data/%s_public_%s_%s_titers.tsv'%(lineage, assay, passage)
@@ -43,7 +43,7 @@ def concatenate_titers(params, passage, assay):
         if len(hi_titers) > 0:
             with open(out, 'w+') as f:
                 call = ['cat'] + hi_titers
-                print call
+                print(call)
                 subprocess.call(call, stdout=f)
 
 if __name__=="__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 biopython >=1.73, ==1.*
 boto >=2.38, ==2.*
-pandas >=0.23.4, ==0.23.*
-rethinkdb >=2.3.0.post6, ==2.3.*
+pandas >=1.1.5, ==1.*
+rethinkdb >=2.4.8, ==2.4.*
 requests >=2.20.0, ==2.*
 unidecode >=1.0.22, ==1.*
 xlrd >=1.0.0, ==1.*

--- a/tdb/append.py
+++ b/tdb/append.py
@@ -1,5 +1,5 @@
 import os, argparse, sys
-import rethinkdb as r
+from rethinkdb import r
 sys.path.append('')  # need to import from base
 from base.rethink_io import rethink_io
 from base.rethink_interact import rethink_interact
@@ -26,4 +26,3 @@ if __name__=="__main__":
     args = parser.parse_args()
     connVDB = append(**args.__dict__)
     connVDB.append(**args.__dict__)
-

--- a/tdb/cdc_upload.py
+++ b/tdb/cdc_upload.py
@@ -98,9 +98,9 @@ class cdc_upload(upload):
         if not meas['serum_id']:
             if 'lot_number' in meas.keys():
                 meas['serum_id'] = 'L' + str(meas['lot_number'])
-            #     print 'new serum id is %s' % (meas['serum_id'])
+            #     print('new serum id is %s' % (meas['serum_id']))
             # else:
-            #     print 'old serum id is %s' % (meas['serum_id'])
+            #     print('old serum id is %s' % (meas['serum_id']))
 
     def remove_fields(self, meas):
         '''

--- a/tdb/cdc_upload.py
+++ b/tdb/cdc_upload.py
@@ -1,6 +1,6 @@
 import os, re, time, datetime, csv, sys, json
 from upload import upload
-import rethinkdb as r
+from rethinkdb import r
 from Bio import SeqIO
 import argparse
 from parse import parse

--- a/tdb/concatenate.py
+++ b/tdb/concatenate.py
@@ -24,7 +24,7 @@ def concat(files):
             for line in f.readlines():
                 line = line.strip()
                 l = "%s\t%s\t%s" % (line, source, passage)
-                print l
+                print(l)
 
 if __name__=="__main__":
     args = parser.parse_args()

--- a/tdb/crick_upload.py
+++ b/tdb/crick_upload.py
@@ -9,10 +9,6 @@ from upload import parser
 sys.path.append('')  # need to import from base
 from base.rethink_io import rethink_io
 from vdb.flu_upload import flu_upload
-# import logging
-# print 'yay'
-# logger = logging.getLogger()
-# print 'more yay'
 
 parser.add_argument('--assay_type', default='hi')
 
@@ -145,9 +141,9 @@ if __name__=="__main__":
             print("Subtype: {}".format(subtype))
             print("Sheet: {}".format(sheet))
             command = "python tdb/elife_upload.py -db " + args.database +  " --subtype " + subtype + " --path ../../fludata/Crick-London-WHO-CC/processed-data/tsv/ --fstem " + sheet + " --preview"
-            print command
+            print(command)
             subprocess.call(command, shell=True)
         else:
             command = "python tdb/elife_upload.py -db " + args.database +  " --subtype " + subtype + " --path ../../fludata/Crick-London-WHO-CC/processed-data/tsv/ --fstem " + sheet
-            print command
+            print(command)
             subprocess.call(command, shell=True)

--- a/tdb/crick_upload.py
+++ b/tdb/crick_upload.py
@@ -1,6 +1,6 @@
 import os, re, time, datetime, csv, sys, json
 from upload import upload
-import rethinkdb as r
+from rethinkdb import r
 from Bio import SeqIO
 import argparse
 import subprocess

--- a/tdb/dengue_download.py
+++ b/tdb/dengue_download.py
@@ -1,5 +1,5 @@
 import os, json, datetime, sys
-import rethinkdb as r
+from rethinkdb import r
 sys.path.append('')  # need to import from base
 from base.rethink_io import rethink_io
 from vdb.download import download as vdb_download

--- a/tdb/download.py
+++ b/tdb/download.py
@@ -1,5 +1,5 @@
 import os, json, datetime, sys, time
-import rethinkdb as r
+from rethinkdb import r
 
 # Enable import from modules in parent directory.
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))

--- a/tdb/elife_upload.py
+++ b/tdb/elife_upload.py
@@ -1,6 +1,6 @@
 import os, re, time, datetime, csv, sys, json
 from upload import upload
-import rethinkdb as r
+from rethinkdb import r
 from Bio import SeqIO
 import argparse
 from parse import parse

--- a/tdb/niid_upload.py
+++ b/tdb/niid_upload.py
@@ -1,6 +1,6 @@
 import os, re, time, datetime, csv, sys, json
 from upload import upload
-import rethinkdb as r
+from rethinkdb import r
 from Bio import SeqIO
 import argparse
 import subprocess

--- a/tdb/niid_upload.py
+++ b/tdb/niid_upload.py
@@ -139,9 +139,9 @@ if __name__=="__main__":
     args.fstem = args.fstem.replace('(','\\(').replace(')','\\)')
     if args.preview:
         command = "python tdb/elife_upload.py -db " + args.database +  " --subtype " + subtype + " --path data/tmp/ --fstem " + args.fstem + " --preview"
-        print command
+        print(command)
         subprocess.call(command, shell=True)
     else:
         command = "python tdb/elife_upload.py -db " + args.database +  " --subtype " + subtype + " --path data/tmp/ --fstem " + args.fstem
-        print command
+        print(command)
         subprocess.call(command, shell=True)

--- a/tdb/nimr_upload.py
+++ b/tdb/nimr_upload.py
@@ -1,6 +1,6 @@
 import os, re, time, datetime, csv, sys, json
 from upload import upload
-import rethinkdb as r
+from rethinkdb import r
 from Bio import SeqIO
 import argparse
 from parse import parse

--- a/tdb/parse.py
+++ b/tdb/parse.py
@@ -43,7 +43,7 @@ class parse(object):
         else:
             with open(file) as infile:
                 table_reader = csv.reader(infile, delimiter="\t")
-                header = table_reader.next()
+                header = next(table_reader)
                 headers = {}
                 for i in range(len(header)):
                     headers[i] = header[i]
@@ -105,12 +105,12 @@ class parse(object):
         with self.myopen(fname) as infile:
             csv_reader = csv.reader(infile)
             # parse sera
-            row1 = csv_reader.next()
-            row2 = csv_reader.next()
-            row3 = csv_reader.next()
+            row1 = next(csv_reader)
+            row2 = next(csv_reader)
+            row3 = next(csv_reader)
             # starting 2016, included passage history row, need to get fourth row
             if self.determine_source_year(src_id) >= 2016:
-                row3 = csv_reader.next()
+                row3 = next(csv_reader)
             fields = self.determine_columns(row1)
             ref_sera_start = len(fields)
             if not all(field in fields for field in ['collection', 'passage']):
@@ -124,7 +124,6 @@ class parse(object):
             row3 = [re.match(r'^([^\*]*)', id).group(0).upper() for id in row3]  # get everything before the '*'?
             ref_sera = [[(e1+'/'+e2), e3.replace(' ', '')] for e1, e2, e3 in zip(row1, row2, row3)[ref_sera_start:]]
             fields = ['source','ref/test'] + fields + map(tuple, ref_sera)
-            #print fields
             for row in csv_reader: # advance until the reference virus
                 if row[0].startswith('REFERENCE'):
                     break
@@ -193,7 +192,7 @@ class parse(object):
                     return float(temp)
             return float(val)
         except:
-            #print "Bad HI measurement:", val
+            #print("Bad HI measurement:", val)
             return np.nan
 
     def check_titer_values(self, titers, src_id):

--- a/tdb/upload.py
+++ b/tdb/upload.py
@@ -148,7 +148,7 @@ class upload(parse, flu_upload):
         Canonicalize strain names to match with vdb
         '''
         # replace all accents with ? mark
-        original_name = name.encode('ascii', 'replace')
+        original_name = name.encode('ascii', 'replace').decode('unicode-escape')
         # Replace whole strain names
         name = self.replace_strain_name(original_name, self.fix_whole_name)
         lookup_month = {'Jan': '1', 'Feb': '2', 'Mar': '3', 'Apr': '4', 'May': '5', 'Jun': '6',
@@ -207,7 +207,7 @@ class upload(parse, flu_upload):
         Determine that strains come from known locations, if not, print suggestion to add location to
         flu_fix_location_label.tsv.
         '''
-        if isinstance(strain, basestring) and "/" in strain:
+        if isinstance(strain, str) and "/" in strain:
             location = strain.split('/')[1]
             if self.determine_location(location) is None:
                 print("Couldn't determine location for this strain, consider adding to flu_fix_location_label.tsv", location, strain)
@@ -390,7 +390,7 @@ class upload(parse, flu_upload):
         '''
         for meas in measurements:
             index = [meas[field] for field in self.index_fields]
-            meas['index'] = hashlib.md5("".join(index)).hexdigest()
+            meas['index'] = hashlib.md5("".join(index).encode()).hexdigest()
             if str(index) in self.indexes:
                 if output:
                     print("Repeat Index: " + str(index) + str(meas['titer']))
@@ -407,9 +407,9 @@ class upload(parse, flu_upload):
 #       print("Filtering out measurements whose serum strain is not paired with a ref or test virus strain ensuring proper formatting")
 #       measurements = filter(lambda meas: meas['serum_strain'] in self.ref_virus_strains or meas['serum_strain'] in self.test_virus_strains, measurements)
         print("Filtering out measurements missing required fields")
-        measurements = filter(lambda meas: self.rethink_io.check_required_attributes(meas, self.upload_fields, self.index_fields, output=True), measurements)
+        measurements = list(filter(lambda meas: self.rethink_io.check_required_attributes(meas, self.upload_fields, self.index_fields, output=True), measurements))
         print("Filtering out measurements with virus, serum strain names or titers not formatted correctly")
-        measurements = filter(lambda meas: self.correct_strain_format(meas['virus_strain'], meas['original_virus_strain']) and self.correct_strain_format(meas['serum_strain'], meas['original_serum_strain']) and self.correct_titer_format(meas['titer']), measurements)
+        measurements = list(filter(lambda meas: self.correct_strain_format(meas['virus_strain'], meas['original_virus_strain']) and self.correct_strain_format(meas['serum_strain'], meas['original_serum_strain']) and self.correct_titer_format(meas['titer']), measurements))
         print(len(measurements), " measurements after filtering")
         return measurements
 
@@ -417,7 +417,7 @@ class upload(parse, flu_upload):
         if re.match("^[0-9<>.]*$", titer):
             return True
         else:
-            print "Bad titer: {}. Removing.".format(titer)
+            print("Bad titer: {}. Removing.".format(titer))
             return False
 
 if __name__=="__main__":

--- a/tdb/upload.py
+++ b/tdb/upload.py
@@ -1,5 +1,5 @@
 import os, re, time, datetime, csv, sys, json
-import rethinkdb as r
+from rethinkdb import r
 import hashlib
 from Bio import SeqIO
 import argparse

--- a/tdb/upload_all.py
+++ b/tdb/upload_all.py
@@ -21,19 +21,19 @@ def upload_nimr(database, nimr_path, subtype):
     of virus (H3N2, H1N1pdm, etc.).
     '''
     path = nimr_path + subtype + "/"
-    print "Uploading NIMR data for subtype", subtype, "contained in directory", path + "."
+    print("Uploading NIMR data for subtype", subtype, "contained in directory", path + ".")
 
     for fname in os.listdir(path):
         if fname[0] != '.':
             fpath = path + fname
             fstem = fname[:-4]
-            print "Uploading " + fname
+            print("Uploading " + fname)
             command = "python tdb/nimr_upload.py -db " + database + " --subtype " + subtype + " --ftype tables --path " + path + " --fstem " + fstem
-            print "Running with: " + command
+            print("Running with: " + command)
             subprocess.call(command, shell=True)
-            print "Done with", fname + "."
+            print("Done with", fname + ".")
 
-    print "Done uploading NIMR documents."
+    print("Done uploading NIMR documents.")
 
 def upload_cdc(database, cdc_path):
     '''
@@ -42,19 +42,19 @@ def upload_cdc(database, cdc_path):
     There are multiple subtypes within a file.
     '''
     path = cdc_path
-    print "Uploading CDC data contained in directory", path + "."
+    print("Uploading CDC data contained in directory", path + ".")
 
     for fname in os.listdir(path):
         if fname[0] != '.':
             fpath = path + fname
             fstem = fname[:-4]
-            print "Uploading " + fname
+            print("Uploading " + fname)
             command = "python tdb/cdc_upload.py -db cdc_tdb --path " + path + " --fstem " + fstem
-            print "Running with: " + command
+            print("Running with: " + command)
             subprocess.call(command, shell=True)
-            print "Done with", fname + "."
+            print("Done with", fname + ".")
 
-    print "Done uploading CDC documents."
+    print("Done uploading CDC documents.")
 
 def upload_elife(database, elife_path, subtype):
     '''
@@ -63,19 +63,19 @@ def upload_elife(database, elife_path, subtype):
     of virus (H3N2, H1N1pdm, etc.).
     '''
     path = elife_path + subtype + "/"
-    print "Uploading eLife data for subtype", subtype, "contained in directory", path + "."
+    print("Uploading eLife data for subtype", subtype, "contained in directory", path + ".")
 
     for fname in os.listdir(path):
         if fname[0] != '.':
             fpath = path + fname
             fstem = fname[:-4]
-            print "Uploading " + fname
+            print("Uploading " + fname)
             command = "python tdb/elife_upload.py -db " + database + " --subtype " + subtype + " --path " + path + " --fstem " + fstem
-            print "Running with: " + command
+            print("Running with: " + command)
             subprocess.call(command, shell=True)
-            print "Done with", fname + "."
+            print("Done with", fname + ".")
 
-    print "Done uploading stored eLife documents."
+    print("Done uploading stored eLife documents.")
 
 def upload_vidrl(database, subtypes):
     with open('data/vidrl_fail_log.txt', 'w') as o:
@@ -98,14 +98,14 @@ def upload_vidrl(database, subtypes):
                     fstem = fname.split('.')[0]
                     if ' ' in fstem:
                         fstem = re.escape(fstem)
-                    print "Uploading " + fname
+                    print("Uploading " + fname)
                     command = "python tdb/vidrl_upload.py -db {} -v flu --subtype {} --assay_type {} --path {} --fstem {} --ftype vidrl".format(database, subtype, assay_type, complete_path, fstem)
-                    print "Running with: " + command
+                    print("Running with: " + command)
                     try:
                         subprocess.call(command, shell=True)
                     except:
                         logger.critical("Couldn't upload {}, please try again.".format(fname))
-                    print "Done with", fname + "."
+                    print("Done with", fname + ".")
 
 def upload_niid(database, subtypes):
     with open('data/niid_fail_log.txt', 'w') as o:
@@ -133,14 +133,14 @@ def upload_niid(database, subtypes):
                     fstem = fstem.replace('(','\\(').replace(')','\\)')
                     if ' ' in fstem:
                         fstem = re.escape(fstem)
-                    print "Uploading " + fname
+                    print("Uploading " + fname)
                     command = "python tdb/niid_upload.py -db {} -v flu --subtype {} --assay_type {} --path {} --fstem {} --ftype niid".format(database, subtype, assay_type, complete_path, fstem)
-                    print "Running with: " + command
+                    print("Running with: " + command)
                     try:
                         subprocess.call(command, shell=True)
                     except:
                         o.writeline("Couldn't upload {}, please try again.".format(infile))
-                    print "Done with", fname + "."
+                    print("Done with", fname + ".")
 
 def upload_crick(database, subtypes):
     with open('data/crick_fail_log.txt', 'w') as o:
@@ -168,14 +168,14 @@ def upload_crick(database, subtypes):
                     fstem = fstem.replace('(','\\(').replace(')','\\)')
                     if ' ' in fstem:
                         fstem = re.escape(fstem)
-                    print "Uploading " + fname
+                    print("Uploading " + fname)
                     command = "python tdb/crick_upload.py -db {} -v flu --subtype {} --assay_type {} --path {} --fstem {} --ftype tables".format(database, subtype, assay_type, complete_path, fstem)
-                    print "Running with: " + command
+                    print("Running with: " + command)
                     try:
                         subprocess.call(command, shell=True)
                     except:
                         o.writeline("Couldn't upload {}, please try again.".format(infile))
-                    print "Done with", fname + "."
+                    print("Done with", fname + ".")
 
 if __name__=="__main__":
     params = parser.parse_args()
@@ -187,7 +187,7 @@ if __name__=="__main__":
     # root_logger.addHandler(ColorizingStreamHandler())
     # logger = logging.getLogger(__name__)
 
-    print "Beginning construction of", params.database + "."
+    print("Beginning construction of", params.database + ".")
 
     if params.subtypes is None:
         params.subtypes = ['h3n2', 'h1n1pdm', 'vic', 'yam']
@@ -212,4 +212,4 @@ if __name__=="__main__":
         if source == "crick":
             upload_crick(params.database, params.subtypes)
 
-    print "Done with all uploads."
+    print("Done with all uploads.")

--- a/tdb/utils/fix_input_file_spaces.py
+++ b/tdb/utils/fix_input_file_spaces.py
@@ -18,7 +18,7 @@ def fix_input_file_spaces():
                         fstem = re.escape(fstem)
                         fname = "{}.{}".format(fstem,fext)
                         command = 'mv {}{} {}{}'.format(complete_path, fname, complete_path, new_fname)
-                        print command
+                        print(command)
                         subprocess.call(command, shell=True)
 
 if __name__=="__main__":

--- a/tdb/vidrl_upload.py
+++ b/tdb/vidrl_upload.py
@@ -1,7 +1,7 @@
 import os, re, time, datetime, csv, sys, json, errno
 import pandas as pd
 from upload import upload
-import rethinkdb as r
+from rethinkdb import r
 from Bio import SeqIO
 import argparse
 import subprocess

--- a/tdb/vidrl_upload.py
+++ b/tdb/vidrl_upload.py
@@ -64,7 +64,7 @@ def convert_xls_to_csv(path, fstem, ind):
             writer.writerows(sheet.row_values(row) for row in range(10))
             # Edit row containing serum strains
             # if '/' in sheet.row_values(10)[4].strip() and '/' in sheet.row_values(12)[2].strip():
-            #     print sheet.row_values(12)[4]
+            #     print(sheet.row_values(12)[4])
             # else:
             #     raise ValueError
             # assume there all always 12 reference viruses in a table
@@ -176,11 +176,11 @@ if __name__=="__main__":
     if args.subtype:
         if args.preview:
             command = "python tdb/elife_upload.py -db " + args.database +  " --subtype " + args.subtype + " --path data/tmp/ --fstem " + args.fstem + " --preview"
-            print command
+            print(command)
             subprocess.call(command, shell=True)
         else:
             command = "python tdb/elife_upload.py -db " + args.database +  " --subtype " + args.subtype + " --path data/tmp/ --fstem " + args.fstem
-            print command
+            print(command)
             subprocess.call(command, shell=True)
     else:
         print("Subtype needs to be specified with --subtype")

--- a/vdb/append.py
+++ b/vdb/append.py
@@ -1,5 +1,5 @@
 import os, argparse, sys
-import rethinkdb as r
+from rethinkdb import r
 sys.path.append('')  # need to import from base
 from base.rethink_io import rethink_io
 from base.rethink_interact import rethink_interact
@@ -37,4 +37,3 @@ if __name__=="__main__":
     args = parser.parse_args()
     connVDB = append(**args.__dict__)
     connVDB.append(**args.__dict__)
-

--- a/vdb/avian_flu_upload.py
+++ b/vdb/avian_flu_upload.py
@@ -282,12 +282,12 @@ class flu_upload(upload):
                 pass
             del doc['Host_Age']
         if 'Host_Age_Unit' in doc:
-            if isinstance(doc['Host_Age_Unit'], basestring):
+            if isinstance(doc['Host_Age_Unit'], str):
                 temp_age_unit = doc['Host_Age_Unit'].lower()
             else:
                 temp_age_unit = 'y'
             del doc['Host_Age_Unit']
-        if isinstance(temp_age, basestring) and isinstance(temp_age_unit, basestring):
+        if isinstance(temp_age, str) and isinstance(temp_age_unit, str):
             doc['age'] = temp_age + temp_age_unit
         return doc
 
@@ -298,21 +298,21 @@ class flu_upload(upload):
         reader = csv.DictReader(filter(lambda row: row[0]!='#', open(fname)), delimiter='\t')
         fix_location = {}
         for line in reader:
-            fix_location[line['label'].decode('unicode-escape')] = line['fix']
+            fix_location[line['label'].encode().decode('unicode-escape')] = line['fix']
         return fix_location
 
     def define_location_label_fixes(self, fname):
         reader = csv.DictReader(filter(lambda row: row[0]!='#', open(fname)), delimiter='\t')
         self.label_to_fix = {}
         for line in reader:
-            self.label_to_fix[line['label'].decode('unicode-escape').replace(' ', '').lower()] = line['fix']
+            self.label_to_fix[line['label'].encode().decode('unicode-escape').replace(' ', '').lower()] = line['fix']
 
     def fix_name(self, name):
         '''
         Fix strain names
         '''
         # replace all accents with ? mark
-        original_name = name.encode('ascii', 'replace')
+        original_name = name.encode('ascii', 'replace').decode('unicode-escape')
         # return original_name, original_name
         # Replace whole strain names
         name = self.replace_strain_name(original_name, self.fix_whole_name)
@@ -330,7 +330,7 @@ class flu_upload(upload):
                 split_name[index] = self.label_to_fix[label.replace(' ', '').lower()]
         name = '/'.join(split_name)
         name = self.flu_fix_patterns(name)
-        
+
         # Strip leading zeroes, change all capitalization location field to title case
         split_name = name.split('/')
         if len(split_name) == 4:
@@ -369,30 +369,30 @@ class flu_upload(upload):
         Fix host formatting
         '''
         avian_list = ["accipitergentilis", "accipiternisus", "accipitertrivirgatus",
-                     "african__stonechat","aixgalericulata", "alectorischukar","american__black__duck", 
+                     "african__stonechat","aixgalericulata", "alectorischukar","american__black__duck",
                      "american__wigeon","anasboschas", "anasacuta","anasamericana", "anaspenelope",
                      "anseranserdomesticus","anserbrachyrhynchus","ansercanagica","anasquerquedula",
-                     "anascarolinensis", "anasclypeata", "anascrecca", "anascyanoptera", 
-                     "anasdiscors", "anasformosa", "anasplatyrhynchos","anaspoecilorhyncha", 
+                     "anascarolinensis", "anasclypeata", "anascrecca", "anascyanoptera",
+                     "anasdiscors", "anasformosa", "anasplatyrhynchos","anaspoecilorhyncha",
                      "anasrubripes", "anassp.", "anasstrepera", "anasstrepera","anasplatyrhynchosvar.domesticus",
                      "anasundalata", "anseranser", "anserfabalis","anseralbifrons","anthropoidesvirgo",
                      "anserindicus", "arenariainterpres", "avian","bar__headed__goose", "bird",
-                     "barn__swallow","brown__headed__gull","bucephalaclangula", "buteo", 
+                     "barn__swallow","brown__headed__gull","bucephalaclangula", "buteo",
                      "baikal__teal","bewick's__swan","black__billed__magpie","babbler",
                      "buteobuteo", "blue__winged__teal","cairinamoschata", "canada__goose",
                      "chencanagica", "chicken","chukar","cormorant","corvus", "common__pochard",
                      "common__goldeneye","common__coot","common__pheasant","condor",
                      "coturnix","coturnixsp.","coturniccoturnix","coturnixjaponica",
                       "crane","crow","curlew","cygnusatratus","chinese__francolin",
-                     "corvussplendens","cygnuscolumbianus", "cygnuscygnus", "cygnusolor", 
+                     "corvussplendens","cygnuscolumbianus", "cygnuscygnus", "cygnusolor",
                      "duck","dove", "eagle","egret", "eurasian__eagel__owl",
-                     "eurasian__wigeon","falco", "falcon", 
+                     "eurasian__wigeon","falco", "falcon",
                      "falcoperegrinus","finch","francolinus", "fowl",
-                     "falcotinnunculus","gadwall","gallus","gallusgallus", "gallusgallusdomesticus", 
+                     "falcotinnunculus","gadwall","gallus","gallusgallus", "gallusgallusdomesticus",
                      "goose", "graculareligiosa", "great__black__headed__gull","garrulaxcanorus","garganey",
                      "great__crested__grebe","greatbustard","great__bustard",
                      "greater__white__fronted__goose","grebe","green__winged__teal",
-                     "green-wingedteal","grey__heron","guineafowl", "gull", 
+                     "green-wingedteal","grey__heron","guineafowl", "gull",
                      "heron","hirundorustica","houbara__bustard","japanese__white__eye","japanese__quail",
                      "larusschistisagus", "larusargentatus", "larusbrunnicephalus","larusmelanocephalus",
                      "larusatricilla","laruscanus","laughing__gull",
@@ -400,19 +400,19 @@ class flu_upload(upload):
                      "little__egret","lophuranycthemera","magpie","magpie__robin","mallard","murre",
                      "morphnusguianensis", "mute__swan", "muscovy__duck","myna","meleagrisgallopavo",
                      "necrosyrtesmonachus", "nisaetusnipalensis","northern__shoveler","northernshoveler",
-                     "northern__pintail","openbill__stork","ostrich", "oystercatcher","otheravian", 
-                     "partridge","passerdomesticus", "parakeet","parrot","passerine", "passermontanus", 
+                     "northern__pintail","openbill__stork","ostrich", "oystercatcher","otheravian",
+                     "partridge","passerdomesticus", "parakeet","parrot","passerine", "passermontanus",
                      "pavocristatus","peacock","phasianuscolchicus","pheasant",
                      "peregrine__falcon","pigeon","pink__footed__goose","polyplectronbicalcaratum","poultry",
                      "quail","rook","ruddy__turnstone","rosy__billed__pochard",
-                     "saker__falcon","sanderling","shrike","silky__chicken","snow__goose", 
+                     "saker__falcon","sanderling","shrike","silky__chicken","snow__goose",
                      "shorebird","sparrow","starling","swan","stork","swiftlet","tadornaferuginea",
                      "teal","turkey","turtledove", "tree__sparrow","us_quail", "waterfowl",
                      "wild__turkey","white__bellied__bustard","wild__chicken","wild__duck",
                      "whooper__swan","wildbird","yellow__billed__duck","zosteropsjaponicus"]
         environment_list = ["feces", "otherenvironment", "surfaceswab", "watersample","environment"]
         nonhuman_mammal_list = ["bat","canine", "equine", "feline", "mammals", "mink", "othermammals",
-                     "swine","susscrofadomesticus", "lion", "weasel","raccoon__dog","tiger", 
+                     "swine","susscrofadomesticus", "lion", "weasel","raccoon__dog","tiger",
                      "dog","large__cat","pika"]
         other_list = ["circus", "ferret", "insect", "laboratoryderived", "unknown","animal"]
 
@@ -423,7 +423,7 @@ class flu_upload(upload):
 #                 print(v['strain'], "only has 4 fields but is labelled as not human", v['host'])
 #             if len(v['strain'].split('/')) == 5 and v['host'] == 'human':
 #                 print(v['strain'], "has 5 fields but is labelled as human", v['host'])
-            
+
             if v['host'] in avian_list:
                 v['host'] = "avian"
             elif v['host'] in environment_list:
@@ -435,7 +435,7 @@ class flu_upload(upload):
 
             elif v['host'] in ['human']:
                 v['host'] = "human"
-            
+
             # if no host attribute, but there is a host in strain name
             elif v['host'] == '' and len(v['strain'].split("/")) == 5:
                 hostspecies = v['strain'].split("/")[1]
@@ -447,14 +447,14 @@ class flu_upload(upload):
                     v['host'] = 'nonhuman_mammal'
                 elif hostspecies in other_list:
                     v['host'] = 'other'
-                
+
             else:
                 print("cannot classify host for", v['strain'], v['host'])
 
 
     def format_country(self, v, data_source):
         '''
-        
+
         Label viruses with country based on strain name
         A/Taiwan/1/2013 is human virus. Four fields total. Take second field.
         A/Chicken/Taiwan/1/2013 is animal virus. Five field total. Take third field.
@@ -473,23 +473,23 @@ class flu_upload(upload):
         elif field_count == 5:
             loc = strain_name.split('/')[2].replace(" ", "")
             result = self.determine_location(loc)
-        
+
         """there are some old avian viruses whose strain names are incorrectly formatted
         and are missing a strain identifier. Therefore, they are only 4 fields long instead
         of 5. For most of these, the location errors out, but for Turkey viruses, because
         Turkey is an actual country, these will be mislabelled as West Asian. This line
-        will check whether the strain name is only 4 fields and has turkey in it, and if 
+        will check whether the strain name is only 4 fields and has turkey in it, and if
         the location field is not also Turkey, it will print out this error message"""
         if len(strain_name.split('/')) == 4 and "turkey" in strain_name.lower():
             print("check location for", strain_name, original_name, "location ",loc)
 
-            
+
         if data_source == "gisaid":
             if v['gisaid_location'] is not None and result is None:
                 loc = v['gisaid_location'].split('/')[-1].replace(" ", "")
                 result = self.determine_location(loc)
         if data_source == 'ird':
-            if field_count == 4 and v['host'].lower() == 'human': 
+            if field_count == 4 and v['host'].lower() == 'human':
                 loc = strain_name.split("/")[1]
             elif field_count == 4 and v['host'].lower() != 'human':
                 loc = strain_name.split("/")[2]
@@ -506,8 +506,8 @@ class flu_upload(upload):
             v['location'], v['division'], v['country'] = None, None, None
             print("couldn't parse country for ", original_name)
 
-	if v['division'] == v['country']:
-	    v['division'] == '?'
+        if v['division'] == v['country']:
+            v['division'] == '?'
 
         if v['division'] == v['country']:
             v['division'] == '?'

--- a/vdb/avian_flu_upload.py
+++ b/vdb/avian_flu_upload.py
@@ -1,6 +1,6 @@
 import os, re, time, datetime, csv, sys, json
 import numpy as np
-import rethinkdb as r
+from rethinkdb import r
 from Bio import SeqIO
 from Bio import AlignIO
 from upload import upload

--- a/vdb/coronavirus_upload.py
+++ b/vdb/coronavirus_upload.py
@@ -1,5 +1,5 @@
 import os, re, time, datetime, csv, sys
-import rethinkdb as r
+from rethinkdb import r
 from Bio import SeqIO
 from upload import upload
 from upload import get_parser

--- a/vdb/dengue_upload.py
+++ b/vdb/dengue_upload.py
@@ -1,5 +1,5 @@
 import os, re, time, datetime, csv, sys
-import rethinkdb as r
+from rethinkdb import r
 from Bio import SeqIO
 from upload import upload
 from upload import get_parser

--- a/vdb/download.py
+++ b/vdb/download.py
@@ -1,5 +1,5 @@
 import os, json, datetime, sys, re
-import rethinkdb as r
+from rethinkdb import r
 from Bio import SeqIO
 import numpy as np
 

--- a/vdb/ebola_upload.py
+++ b/vdb/ebola_upload.py
@@ -1,5 +1,5 @@
 import os, re, time, datetime, csv, sys
-import rethinkdb as r
+from rethinkdb import r
 from Bio import SeqIO
 from upload import upload
 from upload import get_parser

--- a/vdb/flu_update.py
+++ b/vdb/flu_update.py
@@ -57,7 +57,7 @@ class flu_update(update, flu_upload):
             list_viruses = [viruses]
         print("Determining groupings for " + str(len(viruses)) + " viruses in " + str(len(list_viruses)) + " batches of " + str(optimal_upload) + " viruses at a time")
         for group_num, virus_group in enumerate(list_viruses):
-            print("Group " + str(group_num+1)) + " out of " + str(len(list_viruses)) + " groupings"
+            print("Group " + str(group_num+1) + " out of " + str(len(list_viruses)) + " groupings")
             for virus in virus_group:
                 for acc in virus['sequences']:
                     if acc in accession_to_sequence_doc:

--- a/vdb/flu_update.py
+++ b/vdb/flu_update.py
@@ -1,6 +1,6 @@
 import os
 import numpy as np
-import rethinkdb as r
+from rethinkdb import r
 from Bio import SeqIO
 from update import update
 from flu_upload import flu_upload

--- a/vdb/flu_upload.py
+++ b/vdb/flu_upload.py
@@ -1,6 +1,6 @@
 import os, re, time, datetime, csv, sys, json
 import numpy as np
-import rethinkdb as r
+from rethinkdb import r
 from Bio import SeqIO
 from Bio import AlignIO
 from upload import upload

--- a/vdb/flu_upload.py
+++ b/vdb/flu_upload.py
@@ -3,9 +3,10 @@ import numpy as np
 from rethinkdb import r
 from Bio import SeqIO
 from Bio import AlignIO
-from upload import upload
-from upload import get_parser
 from unidecode import unidecode
+sys.path.append('')  # need to import from base
+from vdb.upload import upload
+from vdb.upload import get_parser
 
 parser = get_parser()
 parser.add_argument('--upload_directory', default=False, action="store_true", help='upload all xls and fasta files in directory')
@@ -222,12 +223,12 @@ class flu_upload(upload):
                 pass
             del doc['Host_Age']
         if 'Host_Age_Unit' in doc:
-            if isinstance(doc['Host_Age_Unit'], basestring):
+            if isinstance(doc['Host_Age_Unit'], str):
                 temp_age_unit = doc['Host_Age_Unit'].lower()
             else:
                 temp_age_unit = 'y'
             del doc['Host_Age_Unit']
-        if isinstance(temp_age, basestring) and isinstance(temp_age_unit, basestring):
+        if isinstance(temp_age, str) and isinstance(temp_age_unit, str):
             doc['age'] = temp_age + temp_age_unit
         return doc
 
@@ -235,7 +236,7 @@ class flu_upload(upload):
         reader = csv.DictReader(filter(lambda row: row[0]!='#', open(fname)), delimiter='\t')
         self.label_to_fix = {}
         for line in reader:
-            self.label_to_fix[line['label'].decode('unicode-escape').replace(' ', '').lower()] = line['fix']
+            self.label_to_fix[line['label'].encode().decode('unicode-escape').replace(' ', '').lower()] = line['fix']
 
     def define_location_fixes(self, fname):
         '''
@@ -244,7 +245,7 @@ class flu_upload(upload):
         reader = csv.DictReader(filter(lambda row: row[0]!='#', open(fname)), delimiter='\t')
         fix_location = {}
         for line in reader:
-            fix_location[line['label'].decode('unicode-escape')] = line['fix']
+            fix_location[line['label'].encode().decode('unicode-escape')] = line['fix']
         return fix_location
 
     def fix_name(self, name):
@@ -252,7 +253,7 @@ class flu_upload(upload):
         Fix strain names
         '''
         # replace all accents with ? mark
-        original_name = name.encode('ascii', 'replace')
+        original_name = name.encode('ascii', 'replace').decode('unicode-escape')
         # Replace whole strain names
         name = self.replace_strain_name(original_name, self.fix_whole_name)
         name = name.replace('H1N1', '').replace('H5N6', '').replace('H3N2', '').replace('Human', '')\

--- a/vdb/measles_upload.py
+++ b/vdb/measles_upload.py
@@ -1,5 +1,5 @@
 import os, re, time, datetime, csv, sys
-import rethinkdb as r
+from rethinkdb import r
 from Bio import SeqIO
 from upload import upload
 from upload import get_parser

--- a/vdb/mumps_upload.py
+++ b/vdb/mumps_upload.py
@@ -1,5 +1,5 @@
 import os, re, time, datetime, csv, sys
-import rethinkdb as r
+from rethinkdb import r
 from Bio import SeqIO
 from upload import upload
 from upload import get_parser
@@ -28,7 +28,7 @@ class mumps_upload(upload):
         for field in ['host']:
             if field in document and document[field] is not None:
                 document[field] = self.camelcase_to_snakecase(document[field])
-                
+
     def format_viruses(self, documents, **kwargs):
         '''
         format virus information in preparation to upload to database table

--- a/vdb/ncov_upload.py
+++ b/vdb/ncov_upload.py
@@ -1,5 +1,5 @@
 import os, re, time, datetime, csv, sys
-import rethinkdb as r
+from rethinkdb import r
 from Bio import SeqIO
 from upload import upload
 from upload import get_parser

--- a/vdb/parse.py
+++ b/vdb/parse.py
@@ -220,7 +220,7 @@ class parse(object):
         queries = []
         giList = []
 
-        for i in sorted(xrange(0, len(accessions), n_entrez)): # split accessions list into 2500-long portions
+        for i in sorted(range(0, len(accessions), n_entrez)): # split accessions list into 2500-long portions
             queries.append(" ".join(accessions[i:i+n_entrez])) # convert list to ' ' separated string
 
         assert sum([len(q.split()) for q in queries]) == len(accessions) # sanity check

--- a/vdb/seattle_upload.py
+++ b/vdb/seattle_upload.py
@@ -1,5 +1,5 @@
 import os, re, time, datetime, csv, sys
-import rethinkdb as r
+from rethinkdb import r
 from Bio import SeqIO
 from upload import upload
 from upload import get_parser

--- a/vdb/sync.py
+++ b/vdb/sync.py
@@ -1,5 +1,5 @@
 import os, argparse, sys
-import rethinkdb as r
+from rethinkdb import r
 sys.path.append('')  # need to import from base
 from base.rethink_io import rethink_io
 from base.rethink_interact import rethink_interact

--- a/vdb/update.py
+++ b/vdb/update.py
@@ -1,5 +1,5 @@
 import os, json
-import rethinkdb as r
+from rethinkdb import r
 from upload import upload
 from upload import get_parser
 

--- a/vdb/upload.py
+++ b/vdb/upload.py
@@ -2,9 +2,9 @@ import os, re, time, datetime, csv, sys, json
 from rethinkdb import r
 from Bio import SeqIO
 import argparse
-from parse import parse
 sys.path.append('')  # need to import from base
 from base.rethink_io import rethink_io
+from vdb.parse import parse
 
 def get_parser():
     parser = argparse.ArgumentParser()
@@ -146,7 +146,7 @@ class upload(parse):
         reader = csv.DictReader(filter(lambda row: row[0]!='#', open(fname)), delimiter='\t')
         fix_whole_name = {}
         for line in reader:
-            fix_whole_name[line['label'].decode('unicode-escape')] = line['fix']
+            fix_whole_name[line['label'].encode().decode('unicode-escape')] = line['fix']
         return fix_whole_name
 
     def define_location_fixes(self, fname):
@@ -156,7 +156,7 @@ class upload(parse):
         reader = csv.DictReader(filter(lambda row: row[0]!='#', open(fname)), delimiter='\t')
         fix_location = {}
         for line in reader:
-            fix_location[line['label'].decode('unicode-escape')] = line['fix']
+            fix_location[line['label'].encode().decode('unicode-escape')] = line['fix']
         return fix_location
 
     def define_date_fixes(self, fname):
@@ -166,7 +166,7 @@ class upload(parse):
         reader = csv.DictReader(filter(lambda row: row[0]!='#', open(fname)), delimiter='\t')
         fix_date = {}
         for line in reader:
-            fix_date[line['label'].decode('unicode-escape')] = line['fix']
+            fix_date[line['label'].encode().decode('unicode-escape')] = line['fix']
         return fix_date
 
     def replace_strain_name(self, original_name, fixes={}):
@@ -255,9 +255,9 @@ class upload(parse):
         self.label_to_country = {}
 
         for line in reader:
-            self.label_to_location[line['label'].decode('unicode-escape').lower()] = self.camelcase_to_snakecase(line['location'])
-            self.label_to_division[line['label'].decode('unicode-escape').lower()] = self.camelcase_to_snakecase(line['division'])
-            self.label_to_country[line['label'].decode('unicode-escape').lower()] = self.camelcase_to_snakecase(line['country'])
+            self.label_to_location[line['label'].encode().decode('unicode-escape').lower()] = self.camelcase_to_snakecase(line['location'])
+            self.label_to_division[line['label'].encode().decode('unicode-escape').lower()] = self.camelcase_to_snakecase(line['division'])
+            self.label_to_country[line['label'].encode().decode('unicode-escape').lower()] = self.camelcase_to_snakecase(line['country'])
 
     def define_regions(self, fname):
         '''
@@ -339,7 +339,7 @@ class upload(parse):
         filter out certain documents
         '''
         print(str(len(documents)) + " documents before filtering")
-        documents = filter(lambda doc: index in doc, documents)
+        documents = list(filter(lambda doc: index in doc, documents))
         print(str(len(documents)) + " documents after filtering")
         return documents
 

--- a/vdb/upload.py
+++ b/vdb/upload.py
@@ -1,5 +1,5 @@
 import os, re, time, datetime, csv, sys, json
-import rethinkdb as r
+from rethinkdb import r
 from Bio import SeqIO
 import argparse
 from parse import parse

--- a/vdb/yellow_fever_upload.py
+++ b/vdb/yellow_fever_upload.py
@@ -1,5 +1,5 @@
 import os, re, time, datetime, csv, sys
-import rethinkdb as r
+from rethinkdb import r
 from Bio import SeqIO
 from upload import upload
 from upload import get_parser

--- a/vdb/zibra_upload.py
+++ b/vdb/zibra_upload.py
@@ -1,5 +1,5 @@
 import os, re, time, datetime, csv, sys
-import rethinkdb as r
+from rethinkdb import r
 from Bio import SeqIO
 from upload import upload
 from upload import get_parser

--- a/vdb/zika_upload.py
+++ b/vdb/zika_upload.py
@@ -1,5 +1,5 @@
 import os, re, time, datetime, csv, sys
-import rethinkdb as r
+from rethinkdb import r
 from Bio import SeqIO
 from upload import upload
 from upload import get_parser


### PR DESCRIPTION
This is PR upgrades Fauna to Python 3. There was no attempt to preserve Python 2 compatibility. The world has moved on. This was done by working through commands in the `builds/` directory and correcting errors as they arose. The codebase was searched to try to fix these errors as broadly as possible (for example converting all uses of `.decode('unicode-escape')` to `.encode().decode('unicode-escape')`). This was tested with:

* `ZIKA.md` upload, download and update
* `FLU.md` upload, download and update sequences, upload CDC titers and download all titers, missing VIDRL, Crick and NIID upload testing as I didn't have ready access to input files for these commands
* `MUMPS.md` upload, download and update, missing preprocess commands as I didn't have ready access to input files for these commands
* `DENGUE.md` upload, download and update sequences, download titers
* `MEASLES.md` upload and download

There are almost certainly more small errors that will arise when running Fauna via Python 3. However, I believe these will be small enough that they can be corrected as they come up. The download functions should all work via `python3` and so individual pathogen builds can be run / updated without needing to touch the Fauna repo.

In addition RethinkDB was updated from 2.3.0 to 2.4.8. There is not a whole lot of new functionality here, but I thought useful to do so to at least be up to date with current RethinkDB documentation.

Pandas requirement was updated to `pandas >=1.1.5, ==1.*` to match new requirements in Augur. This will fix currently conflicting requirements when constructing Nextstrain Docker image.

