### PR TITLE
tdb/cdc_upload: Add filter option for new titers

### DIFF
--- a/source-data/cdc_titer_column_map.tsv
+++ b/source-data/cdc_titer_column_map.tsv
@@ -1,0 +1,12 @@
+label	fix
+ag_cdc_id	virus_cdc_id
+ag_strain_name	virus_strain
+ag_passage	virus_strain_passage
+sr_strain_name	serum_strain
+sr_ferret	ferret_id
+sr_lot	lot_number
+sr_passage	serum_antigen_passage
+test_date	assay_date
+test_subtype	subtype
+titer_value	titer
+test_protocol	assay_type


### PR DESCRIPTION
The CDC is moving to a new table format that includes all titer data.
We should only ingest the titers that are marked reportable.

The new `--filter` option filters for rows where `titer_reportable` is
True and prints the filtered titers to a new TSV with columns that have
been renamed according to `source-data/cdc_titer_column_map.tsv`.
The column names should match previous CDC titer table columns so that
the `cdc_upload` class does not need to be updated.

---

- [x] Waiting on confirmation from the CDC that my interpretation of the `titer_reportable` column is correct. 