### PR TITLE
Include assay and inclusion dates for titer data

### DIFF
--- a/tdb/download.py
+++ b/tdb/download.py
@@ -110,19 +110,19 @@ class download(object):
             handle.close()
             print("Wrote to " + fname)
 
-    def write_text(self, measurements, fname, text_fields=['virus_strain', 'serum_strain', 'serum_id', 'source', 'titer', 'assay_type']):
+    def write_text(self, measurements, fname, text_fields=['virus_strain', 'serum_strain', 'serum_id', 'source', 'titer', 'assay_type', 'assay_date', 'inclusion_date']):
         try:
             handle = open(fname, 'w')
         except IOError:
             pass
         else:
             for meas in measurements:
-                for field in text_fields:
-                    if field in meas and meas[field] is not None:
-                        handle.write(str(meas[field]) + '\t')
-                    else:
-                        handle.write('?' + '\t')
+                handle.write("\t".join([
+                    str(meas.get(field, "?"))
+                    for field in text_fields
+                ]))
                 handle.write('\n')
+
             handle.close()
             print("Wrote to " + fname)
 


### PR DESCRIPTION
### Description of proposed changes    

Adds two date fields to the list of fields to write out from each titer
record, making exploration of titer data by date substantially easier by
avoiding linking of strain dates to test/reference strains.

In addition to adding these two fields, this commit fixes an annoying
bug in the original titer output where a trailing tab character
effectively creates an empty last column that has to be dealt with
during parsing by pandas, etc.

### Testing

Tested by downloading WHO titers for HI and FRA data and filtering these data interactively on their assay date and inclusion date values.