### PR TITLE
Include a header in titer tables

### DIFF
--- a/tdb/download.py
+++ b/tdb/download.py
@@ -116,6 +116,10 @@ class download(object):
         except IOError:
             pass
         else:
+            # Write out field names as a header.
+            handle.write("\t".join(text_fields) + "\n")
+
+            # Write out field values for each record.
             for meas in measurements:
                 for field in text_fields:
                     if field in meas and meas[field] is not None:


### PR DESCRIPTION
### Description of proposed changes    

Adds a header to the titer table output based on the text fields
requested from each record. This change allows users of the resulting
data to easily determine what data they're looking at instead of having
to guess and manually add a header each time they load these data into
pandas, etc.

Although it would be nice to updated Augur's titer model code to use
these headers instead of indexing titer table values by hardcoded column
indices, it looks like Augur should handle the inclusion of a header
column by [skipping the header when its fifth column cannot be converted
to a float](https://github.com/nextstrain/augur/blob/15dfc8bc5c5a570066ddd5601c9aa82e0c1d2b7d/augur/titer_model.py#L72-L75).

### Testing

Tested locally with WHO titers for HI and FRA assays.