### PR TITLE
Revert "Compensate for automatic compression by nextstrain remote upload

### DIFF
--- a/builds/ZIKA.md
+++ b/builds/ZIKA.md
@@ -47,19 +47,19 @@ augur parse \
 
 This results in the files `data/sequences.fasta` and `data/metadata.tsv`.
 
-### Compress sequences
+### Compress
 
 ```
 xz --compress data/sequences.fasta
+gzip data/metadata.tsv
 ```
 
-This results in the files `data/sequences.fasta.xz`.
+This results in the files `data/sequences.fasta.xz` and `data/metadata.tsv.gz`.
 
 ### Push to S3
 
 ```
-mv data/metadata.tsv data/metadata.tsv.gz
 nextstrain remote upload s3://nextstrain-data/files/zika/ data/sequences.fasta.xz data/metadata.tsv.gz
 ```
 
-This pushes files to S3 to be made available at https://data.nextstrain.org/files/zika/sequences.fasta.xz and https://data.nextstrain.org/files/zika/metadata.tsv.gz. Text files are automatically gzipped on upload with `nextstrain remote upload` and so the file is renamed locally to compensate.
+This pushes files to S3 to be made available at https://data.nextstrain.org/files/zika/sequences.fasta.xz and https://data.nextstrain.org/files/zika/metadata.tsv.gz.


### PR DESCRIPTION
This reverts most of commit 0e5176a4477d369a380e1d5a89d53f3b2834f966.
An unrelated filename fix (removing "zika_" prefix from filenames) was
left unreverted.

The instructions around compression were the result of being misled by
curl's default of not unwrapping Content-Encoding (i.e. it must be
enabled by using the --compression option).
