### PR TITLE
document ViPR API call as an alternative download

### DIFF
--- a/builds/ZIKA.md
+++ b/builds/ZIKA.md
@@ -13,6 +13,16 @@
   * Select year >= 2013 and genome length >= 5000
   * Download as Genome Fasta
   * Set Custom Format Fields to 0: GenBank Accession, 1: Strain Name, 2: Segment, 3: Date, 4: Host, 5: Country, 6: Subtype, 7: Virus Species
+  * May also use the [ViPR API](https://www.viprbrc.org/brc/staticContent.spg?decorator=reo&type=ViprInfo&subtype=API)
+
+  ```
+  curl -k "https://www.viprbrc.org/brc/api/sequence?datatype=genome&family=flavi&species=Zika%20virus&fromyear=2003&minlength=5000&metadata=genbank,strainname,segment,date,host,country,genotype,species&output=fasta" |\
+  tr '-' '_' |\
+  tr ' ' '_' |\
+  sed 's:N/A:NA:g' >\
+  GenomicFastaResults.fasta
+  ```
+
 2. Move downloaded sequences to `fauna/data`
 3. Extract `GenomicFastaResults.tar.gz` and rename the extracted file to `GenomicFastaResults.fasta`
 4. Upload to vdb database

--- a/builds/ZIKA.md
+++ b/builds/ZIKA.md
@@ -22,6 +22,15 @@
   sed 's:N/A:NA:g' >\
   GenomicFastaResults.fasta
   ```
+  
+  The search-and-replace commands (`tr`, `sed`) are necessary because the API downloads fasta headers similar to:
+
+  `>KY241742|ZIKV_SG_072|N/A|2016-08-28|Human|Singapore|Asian|Zika virus`
+  
+  but need to match the GUI downloaded headers similar to: 
+  
+  `>KY241742|ZIKV_SG_072|NA|2016_08_28|Human|Singapore|Asian|Zika_virus`
+
 
 2. Move downloaded sequences to `fauna/data`
 3. Extract `GenomicFastaResults.tar.gz` and rename the extracted file to `GenomicFastaResults.fasta`


### PR DESCRIPTION
### Description of proposed changes

Add the ViPR API call as a alternative programmatic method of retrieving sequences. However, keep the documentation on downloading sequences via the GUI for easier comprehension. 

### Testing

Possibly test by downloading sequences from GUI, downloading sequences via API call, and run a `diff` on the two files. 
