### PR TITLE
Fix min year in API call

### DIFF
--- a/builds/ZIKA.md
+++ b/builds/ZIKA.md
@@ -15,7 +15,7 @@
   * May also use the [ViPR API](https://www.viprbrc.org/brc/staticContent.spg?decorator=reo&type=ViprInfo&subtype=API)
 
   ```
-  curl "https://www.viprbrc.org/brc/api/sequence?datatype=genome&family=flavi&species=Zika%20virus&fromyear=2003&minlength=5000&metadata=genbank,strainname,segment,date,host,country,genotype,species&output=fasta" |\
+  curl "https://www.viprbrc.org/brc/api/sequence?datatype=genome&family=flavi&species=Zika%20virus&fromyear=2013&minlength=5000&metadata=genbank,strainname,segment,date,host,country,genotype,species&output=fasta" |\
   tr '-' '_' |\
   tr ' ' '_' |\
   sed 's:N/A:NA:g' >\


### PR DESCRIPTION
### Description of proposed changes

Minimum year should be 2013:

https://github.com/nextstrain/fauna/blob/a1e3840cb43f322afc5c6c027a40d383813303ea/builds/ZIKA.md?plain=1#L12

### Related issue(s)

_N/A_

### Testing

_N/A_