### PR TITLE
preprocess sed command

### DIFF
--- a/builds/MEASLES.md
+++ b/builds/MEASLES.md
@@ -4,12 +4,30 @@
 * This is search fields of `measles[title] AND viruses[filter] AND ("5000"[SLEN] : "20000"[SLEN])`
 * Send to : Complete Record : File : Accession List
 * This downloads the file `sequence.seq`
-* Open this file and remove the `.1`, `.2`, etc... from the accession numbers
+* Remove the `.1`, `.2`, etc... from the accession numbers in `sequence.seq`:
+
+    ```
+    sed -i '' -e 's/.1$//g' -e 's/.2$//g' sequence.seq
+    ```
 
 ## Upload to fauna
 
-`python3 vdb/measles_upload.py -db vdb -v measles --ftype accession --source genbank --locus genome --fname sequence.seq`
+```
+python3 vdb/measles_upload.py \
+  -db vdb \
+  -v measles \
+  --ftype accession \
+  --source genbank \
+  --locus genome \
+  --fname sequence.seq
+```
 
 ## Download from fauna
 
-`python3 vdb/measles_download.py -db vdb -v measles --fstem measles --resolve_method choose_genbank`
+```
+python3 vdb/measles_download.py \
+  -db vdb \
+  -v measles \
+  --fstem measles \
+  --resolve_method choose_genbank
+```


### PR DESCRIPTION
### Description of proposed changes

Add search-and-replace (`sed`) command to drop `.1` and `.2` postfix from accessions.
