### PR TITLE
docs: zstd

### DIFF
--- a/builds/DENGUE.md
+++ b/builds/DENGUE.md
@@ -42,7 +42,7 @@
   ```
   
   * updates `authors`, `title`, `url`, `journal` and `puburl` fields from genbank files
-  * If you get `ERROR: Couldn't connect with entrez, please run again` just run command again    
+  * If you get `ERROR: Couldn't connect with entrez, please run again` just run command again
 
 ## Download sequence documents from VDB
 
@@ -55,3 +55,68 @@
 ## Download titer documents from TDB
 
 * `python3 tdb/download.py -db tdb -v dengue --fstem dengue`
+
+## Prepare for s3 upload
+
+```
+# Download dengue_all
+python3 vdb/download.py \
+  --database vdb \
+  --virus dengue \
+  --fasta_fields strain virus accession collection_date region country division location source locus authors url title journal puburl \
+  --resolve_method choose_genbank \
+  --fstem dengue_all
+
+# Convert to sequences and metadata files
+augur parse \
+  --sequences data/dengue_all.fasta \
+  --output-sequences data/sequences_all.fasta \
+  --output-metadata data/metadata_all.tsv \
+  --fields strain virus accession date region country division city db segment authors url title journal paper_url \
+  --prettify-fields region country division city
+
+# Loop through the 4 serotypes
+ARR=(1 2 3 4)
+
+for TYPE in "${ARR[@]}"; do
+  python3 vdb/download.py \
+    --database vdb \
+    --virus dengue \
+    --fasta_fields strain virus accession collection_date region country division location source locus authors url title journal puburl \
+    --select serotype:Dengue_virus_${TYPE} \
+    --fstem dengue_denv${TYPE}
+
+  # Convert to sequences and metadata files
+  augur parse \
+    --sequences data/dengue_denv${TYPE}.fasta \
+    --output-sequences data/sequences_denv${TYPE}.fasta \
+    --output-metadata data/metadata_denv${TYPE}.tsv \
+    --fields strain virus accession date region country division city db segment authors url title journal paper_url \
+    --prettify-fields region country division city
+done
+```
+
+### Compress
+
+```
+ARR=(all denv1 denv2 denv3 denv4)
+
+for SEROTYPE in "${ARR[@]}" do
+  zstd -T0 data/sequences_${SEROTYPE}.fasta
+  zstd -T0 data/metadata_${SEROTYPE}.tsv
+done
+```
+
+This results in multiple `data/sequences_*.fasta.zst` and `data/metadata_*.tsv.zst` files.
+
+### Push to S3
+
+```
+nextstrain remote upload s3://nextstrain-data/files/dengue/ data/sequences_*.zst data/metadata_*.zst
+```
+
+This pushes files to S3 to be made available at https://data.nextstrain.org/files/dengue/sequences_*.fasta.zst and https://data.nextstrain.org/files/dengue/metadata_*.tsv.zst.
+
+## Run dengue workflow
+
+See instructions at https://github.com/nextstrain/dengue.

--- a/builds/MEASLES.md
+++ b/builds/MEASLES.md
@@ -25,9 +25,46 @@ python3 vdb/measles_upload.py \
 ## Download from fauna
 
 ```
-python3 vdb/measles_download.py \
-  -db vdb \
-  -v measles \
-  --fstem measles \
-  --resolve_method choose_genbank
+python3 vdb/download.py \
+  --database vdb \
+  --virus measles \
+  --fasta_fields strain virus accession collection_date region country division location source locus authors url title journal puburl \
+  --resolve_method choose_genbank \
+  --fstem measles
 ```
+
+This results in the file `data/measles.fasta` with FASTA header ordered as above.
+
+### Parse
+
+```
+augur parse \
+  --sequences data/measles.fasta \
+  --output-sequences data/sequences.fasta \
+  --output-metadata data/metadata.tsv \
+  --fields strain virus accession date region country division city db segment authors url title journal paper_url \
+  --prettify-fields region country division city
+```
+
+This results in the files `data/sequences.fasta` and `data/metadata.tsv`.
+
+### Compress
+
+```
+zstd -T0 data/sequences.fasta
+zstd -T0 data/metadata.tsv
+```
+
+This results in the files `data/sequences.fasta.zst` and `data/metadata.tsv.zst`.
+
+### Push to S3
+
+```
+nextstrain remote upload s3://nextstrain-data/files/measles/ data/sequences.fasta.zst data/metadata.tsv.zst
+```
+
+This pushes files to S3 to be made available at https://data.nextstrain.org/files/measles/sequences.fasta.zst and https://data.nextstrain.org/files/measles/metadata.tsv.zst.
+
+## Run measles workflow
+
+See instructions at https://github.com/nextstrain/measles.

--- a/builds/ZIKA.md
+++ b/builds/ZIKA.md
@@ -74,19 +74,19 @@ This results in the files `data/sequences.fasta` and `data/metadata.tsv`.
 ### Compress
 
 ```
-xz --compress data/sequences.fasta
-gzip data/metadata.tsv
+zstd -T0 data/sequences.fasta
+zstd -T0 data/metadata.tsv
 ```
 
-This results in the files `data/sequences.fasta.xz` and `data/metadata.tsv.gz`.
+This results in the files `data/sequences.fasta.zst` and `data/metadata.tsv.zst`.
 
 ### Push to S3
 
 ```
-nextstrain remote upload s3://nextstrain-data/files/zika/ data/sequences.fasta.xz data/metadata.tsv.gz
+nextstrain remote upload s3://nextstrain-data/files/zika/ data/sequences.fasta.zst data/metadata.tsv.zst
 ```
 
-This pushes files to S3 to be made available at https://data.nextstrain.org/files/zika/sequences.fasta.xz and https://data.nextstrain.org/files/zika/metadata.tsv.gz.
+This pushes files to S3 to be made available at https://data.nextstrain.org/files/zika/sequences.fasta.zst and https://data.nextstrain.org/files/zika/metadata.tsv.zst.
 
 ## Run zika workflow
 


### PR DESCRIPTION
### Description of proposed changes

For the zika, measles, and dengue s3 endpoints; switch from xz and gz to the faster zstd to be consistent with:

* https://github.com/nextstrain/ncov-ingest/pull/345

Filled in details to measles and dengue instructions, to be consistent with zika instructions.

### Related issue(s)

Related to:

* https://github.com/nextstrain/ncov-ingest/pull/345

Related PRs:

* https://github.com/nextstrain/dengue/pull/5
* https://github.com/nextstrain/measles/pull/7
* https://github.com/nextstrain/zika/pull/23

### Testing

- [x] Checks pass

Any proof-reading is welcome! Or edits to the wording.

