### PR TITLE
Fix cdc uploads

### DIFF
--- a/source-data/cdc_titer_column_map.tsv
+++ b/source-data/cdc_titer_column_map.tsv
@@ -3,8 +3,7 @@ ag_cdc_id	virus_cdc_id
 ag_strain_name	virus_strain
 ag_passage	virus_strain_passage
 sr_strain_name	serum_strain
-sr_ferret	ferret_id
-sr_lot	lot_number
+sr_lot	serum_id
 sr_passage	serum_antigen_passage
 test_date	assay_date
 test_subtype	subtype

--- a/tdb/cdc_upload.py
+++ b/tdb/cdc_upload.py
@@ -70,8 +70,7 @@ class cdc_upload(upload):
                 self.ref_virus_strains.add(meas['virus_strain'])
             if meas['ref'] == False:
                 self.test_virus_strains.add(meas['virus_strain'])
-            if "Human" in meas['serum_id']:
-                meas['serum_host'] = 'human'
+            meas['serum_host'] = self.get_serum_host(meas)
             self.rethink_io.check_optional_attributes(meas, self.optional_fields)
             self.remove_fields(meas)
         if len(self.new_different_date_format) > 0:
@@ -112,6 +111,20 @@ class cdc_upload(upload):
         for f in self.removal_fields:
             if f in meas.keys():
                 meas.pop(f,None)
+
+    def get_serum_host(self, meas):
+        """
+        Returns the serum host based on whether the host is in the measurement's serum id.
+        The default serum host is 'ferret' if there are no matches for other hosts.
+        """
+        # These are known serum hosts that exist in the CDC titer data
+        known_serum_hosts = ['human', 'mouse']
+        for host in known_serum_hosts:
+            if re.search(host, meas['serum_id'], re.IGNORECASE):
+                return host
+
+        return 'ferret'
+
 
     def clean_field_names(self, measurements):
         '''

--- a/tdb/cdc_upload.py
+++ b/tdb/cdc_upload.py
@@ -71,6 +71,9 @@ class cdc_upload(upload):
             if meas['ref'] == False:
                 self.test_virus_strains.add(meas['virus_strain'])
             meas['serum_host'] = self.get_serum_host(meas)
+            # Update serum passage category for human pool serum using the serum id
+            if meas['serum_host'] == 'human':
+                self.format_passage(meas, 'serum_id', 'serum_passage_category')
             self.rethink_io.check_optional_attributes(meas, self.optional_fields)
             self.remove_fields(meas)
         if len(self.new_different_date_format) > 0:


### PR DESCRIPTION
### Description of proposed changes
Fixes a couple of CDC titer upload issues:
- #126 
- #130
- #129 

The `serum_id` and `serum_passage_category` fields are part of the [upload index fields](https://github.com/nextstrain/fauna/blob/bcf3a46e2fee676eb0dec6b69fd406bf5d4bf815/tdb/upload.py#L51), so we will need to delete records from `cdc_tdb/flu` before we can upload data with these new changes. 


<!-- What is the goal of this pull request? What does this pull request change? -->

### TODOs
- [x] Tested with uploads of the CDC titer data to the testing titer database `test_tdb/flu`.
- [x] Do various downloads from `test_tdb/flu` to make sure
  - `serum_host` is correctly parsed for "human" and "mouse"
  - `serum_passage_category` is correctly parsed for human pool sera
- [ ] Delete appropriate records from `cdc_tdb/flu`, maybe filter via `assay_date`. The earliest `assay_date` included in the current CDC database dump is 2019-09-03.


<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
