### PR TITLE
Avian flu upload additions

### DIFF
--- a/vdb/avian_flu_download.py
+++ b/vdb/avian_flu_download.py
@@ -9,7 +9,7 @@ class flu_download(download):
 if __name__=="__main__":
     parser = get_parser()
     args = parser.parse_args()
-    fasta_fields = ['strain', 'virus', 'accession', 'collection_date', 'host', 'region', 'country', 'division', 'location', 'passage_category', 'submitting_lab', 'virus_inclusion_date','h5_clade']
+    fasta_fields = ['strain', 'virus', 'accession', 'collection_date', 'host', 'domestic_status','region', 'country', 'division', 'location', 'passage_category', 'originating_lab','submitting_lab','authors', 'INSDC_accession','PMID','virus_inclusion_date','h5_clade']
     args.fasta_fields = fasta_fields
     current_date = str(datetime.datetime.strftime(datetime.datetime.now(),'%Y_%m_%d'))
     if args.fstem is None:

--- a/vdb/avian_flu_upload.py
+++ b/vdb/avian_flu_upload.py
@@ -204,6 +204,7 @@ class flu_upload(upload):
             self.format_host(doc)
             self.format_domestic_status(doc)
             self.format_animal_health_status(doc)
+            self.format_authors(doc)
             self.determine_group_fields(doc, self.patterns)
             if args.data_source == 'ird':
                 self.format_ird_date(doc)
@@ -387,6 +388,9 @@ class flu_upload(upload):
         if v['animal_health_status'] is not None: 
             v['animal_health_status'] = v['animal_health_status'].strip().lower()
 
+    def format_authors(self, v):
+        if v['authors'] is not None: 
+            v['authors'] = v['authors'].replace("\r","").replace("\n","")
 
     def format_host(self, v):
         '''

--- a/vdb/avian_flu_upload.py
+++ b/vdb/avian_flu_upload.py
@@ -202,6 +202,8 @@ class flu_upload(upload):
             self.fix_casing(doc, args.data_source)
             self.fix_age(doc)
             self.format_host(doc)
+            self.format_domestic_status(doc)
+            self.format_animal_health_status(doc)
             self.determine_group_fields(doc, self.patterns)
             if args.data_source == 'ird':
                 self.format_ird_date(doc)
@@ -377,6 +379,15 @@ class flu_upload(upload):
                 name = re.match(r'([\w\s\-/]+)/([0-9][0-9])$', name).group(1) + "/19" + year
         return name
 
+    def format_domestic_status(self, v):
+        if v['domestic_status'] is not None: 
+            v['domestic_status'] = v['domestic_status'].strip().lower()
+            
+    def format_animal_health_status(self, v):
+        if v['animal_health_status'] is not None: 
+            v['animal_health_status'] = v['animal_health_status'].strip().lower()
+
+
     def format_host(self, v):
         '''
         Fix host formatting
@@ -467,12 +478,6 @@ class flu_upload(upload):
             "circus", "ferret", "insect", "laboratoryderived", "unknown", "animal"]
 
         if v['host'] is not None:
-
-#             """print an error if the length of the strain does not match the host"""
-#             if len(v['strain'].split('/')) == 4 and v['host'] != 'human':
-#                 print(v['strain'], "only has 4 fields but is labelled as not human", v['host'])
-#             if len(v['strain'].split('/')) == 5 and v['host'] == 'human':
-#                 print(v['strain'], "has 5 fields but is labelled as human", v['host'])
 
             if v['host'] in avian_list:
                 v['host'] = "avian"
@@ -619,13 +624,16 @@ class flu_upload(upload):
 if __name__=="__main__":
     args = parser.parse_args()
     if (args.data_source == 'gisaid'):
-        sequence_fasta_fields = {0: 'accession', 1: 'strain', 2: 'isolate_id', 3:'locus', 4: 'passage', 5: 'submitting_lab'}
-        #>B/Austria/896531/2016  | EPI_ISL_206054 | 687738 | HA | Siat 1
+        sequence_fasta_fields = {0: 'accession', 1: 'strain', 2: 'isolate_id', 3:'locus', 4: 'passage', 5: 'submitting_lab', 11: 'originating_lab', 17: 'INSDC_accession'}
+        #gisaid fasta fields: 
+        # DNA Accession no.|Isolate name | Isolate ID | Segment | Passage details/history | Submitting lab | Collection date | Submitter | Sample ID by sample provider | Sample ID by submitting lab | Last modified | Originating lab | Submitting lab | Segment | Segment number | Identifier | DNA Accession no. | DNA INSDC | DNA Accession no. | Isolate name  | I
         setattr(args, 'fasta_fields', sequence_fasta_fields)
         xls_fields_wanted = [('strain', 'Isolate_Name'), ('isolate_id', 'Isolate_Id'), ('collection_date', 'Collection_Date'),
                                  ('host', 'Host'), ('Subtype', 'Subtype'), ('Lineage', 'Lineage'),
                                  ('gisaid_location', 'Location'), ('originating_lab', 'Originating_Lab'), ('Host_Age', 'Host_Age'),
-                                 ('Host_Age_Unit', 'Host_Age_Unit'), ('gender', 'Host_Gender'), ('submission_date', 'Submission_Date')]
+                                 ('Host_Age_Unit', 'Host_Age_Unit'), ('gender', 'Host_Gender'), ('submission_date', 'Submission_Date'),
+                                 ('submitting_lab', 'Submitting_Lab'), ('authors','Authors'), ('domestic_status','Domestic_Status'), 
+                                 ('PMID','PMID'), ('animal_health_status','Animal_Health_Status')]
         setattr(args, 'xls_fields_wanted', xls_fields_wanted)
     elif (args.data_source == 'ird'):
         virus_fasta_fields = {0:'strain', 4: 'vtype', 5: 'Subtype', 6:'collection_date', 8:'country', 10: 'host', 11:'h5_clade'}


### PR DESCRIPTION
### Description of proposed changes

The avian influenza builds require a few updates to make sure that they are displaying the most complete and accurate metadata. In particular, since the initial build, GISAID has added a metadata field describing whether sequences from animals were sampled from domestic or wild animals, which is a useful annotation to display. Additionally, it would be nice to include author information on the tips, as well as data on originating lab and any linked pubmed references. Finally, for sequences that are pulled into GISAID from public databases, it is nice to be able to link those sequences back to their original, public database accession numbers so that the original data entry can be referenced. This pull request makes a few simple edits in `avian_flu_upload.py` and `avian_flu_download.py` to allow these pieces of metadata to be uploaded into vdb. 

### Testing
To test this pull request, I uploaded a series of files into `test_vdb` and confirmed manually that they imported the correct information. Subsequently, I updated existing data in `vdb` with these new fields and have run through the parse step in the `avian-flu` build to confirm that the metadata is parsing as expected. 