### PR TITLE
Gisaid clade and download changes

### DIFF
--- a/source-data/avian_flu_strain_name_fix.tsv
+++ b/source-data/avian_flu_strain_name_fix.tsv
@@ -1082,4 +1082,353 @@ A/duck broiler/Malaysia/F189/07/04	A/duck_broiler/Malaysia/F18907/04
 A/duck/Saraburi/Thailand/CU-74/04	A/duck/Saraburi/ThailandCU74/04
 A/duck/Nakhon Pathom/Thailand/CU-71/04	A/duck/Nakhon_Pathom/ThailandCU71/04
 A/duck/Chonburi/Thailand/CU-5/04	A/duck/Chonburi/ThailandCU5/04
+A/Turkey/Sweden/SVA210214SZ0002/KN035667-IP5/2021	A/Turkey/Sweden/SVA210214SZ0002KN035667IP5/2021
+A/Chicken/Sweden/SVA210217SZ0001/KN001190-IP6/2021	A/Chicken/Sweden/SVA210217SZ0001KN001190IP6/2021
+A/black-headed gull/Sweden/SVA210216SZ0398/KN000437/2021	A/blackheadedgull/Sweden/SVA210216SZ0398KN000437/2021
+A/European herring gull/Sweden/SVA210617SZ0354/FB002251/I-2021	A/Europeanherringgull/Sweden/SVA210617SZ0354FB002251/I2021
+A/common eider/Sweden/SVA210617SZ0354/FB002252/I-2021	A/commoneider/Sweden/SVA210617SZ0354FB002252/I2021
+A/Env/Guangdong/C17059172/YF/2017-03-06	A/Env/Guangdong/C17059172YF/20170306
+A/Env/Guangdong/zhanjiang/C17277346/2017-12-05	A/Env/Guangdong/zhanjiangC17277346/20171205
+A/Duck/Guangdong/PO17281256/MZH/2017-8-21	A/Duck/Guangdong/PO17281256MZH/2017821
+A/Env/Guangdong/C172811415/MZH/2017-10-16	A/Env/Guangdong/C172811415MZH/20171016
+A/Duck/Guangdong/PO17281388/MZH/2017-10-24	A/Duck/Guangdong/PO17281388MZH/20171024
+A/Env/Guangdong/C172811414/MZH/2017-10-16	A/Env/Guangdong/C172811414MZH/20171016
+A/Env/Guangdong/zhanjiang/C18277209/2018-05-21	A/Env/Guangdong/zhanjiangC18277209/20180521
+A/Env/Guangdong/Huizhou/C18280077/2018-02-22	A/Env/Guangdong/HuizhouC18280077/20180222
+A/Env/Guangdong/Huizhou/C18280031/2018-01-22	A/Env/Guangdong/HuizhouC18280031/20180122
+A/Env/Guangdong/zhongshan/C182870234/2018-04-24	A/Env/Guangdong/zhongshanC182870234/20180424
+A/Env/Guangdong/Huizhou/C17280804/2017-11-21	A/Env/Guangdong/HuizhouC17280804/20171121
+A/Env/Guangdong/zhanjiang/C18277050/2018-01-29	A/Env/Guangdong/zhanjiangC18277050/20180129
+A/Env/Guangdong/Shenzhen/C18061184/2018-05-08	A/Env/Guangdong/ShenzhenC18061184/20180508
+A/Env/Guangdong/Qingyuan/C18285099/2018-02-28	A/Env/Guangdong/QingyuanC18285099/20180228
+A/Env/Guangdong/Foshan/C182750200/2018-03-06	A/Env/Guangdong/FoshanC182750200/20180306
+A/Env/Guangdong/Foshan/C182753007/2018-01-02	A/Env/Guangdong/FoshanC182753007/20180102
+A/Env/Guangdong/Foshan/C172750608/2017-12-26	A/Env/Guangdong/FoshanC172750608/20171226
+A/Env/Guangdong/Foshan/C172750600/2017-12-26	A/Env/Guangdong/FoshanC172750600/20171226
+A/Env/Guangdong/Foshan/C172750528/2017-12-05	A/Env/Guangdong/FoshanC172750528/20171205
+A/Env/Guangdong/Dongguan/C172863577/2017-12-04	A/Env/Guangdong/DongguanC172863577/20171204
+A/Env/Guangdong/C17272382/SHG/2017-11-14	A/Env/Guangdong/C17272382SHG/20171114
+A/Env/Guangdong/C172752325/FSH/2017-11-27	A/Env/Guangdong/C172752325FSH/20171127
+A/Env/Guangdong/C172752326/FSH/2017-11-27	A/Env/Guangdong/C172752326FSH/20171127
+A/Env/Guangdong/zhongshan/C182870028/2018-01-15	A/Env/Guangdong/zhongshanC182870028/20180115
+A/Env/Guangdong/C172752329/FSH/2017-11-27	A/Env/Guangdong/C172752329FSH/20171127
+A/Env/Guangdong/Foshan/C182750024/2018-01-09	A/Env/Guangdong/FoshanC182750024/20180109
+A/Env/Guangdong/Jieyang/C17289387/2017-12-05	A/Env/Guangdong/JieyangC17289387/20171205
+A/Env/Guangdong/Jieyang/C17289388/2017-12-05	A/Env/Guangdong/JieyangC17289388/20171205
+A/Env/Guangdong/Jieyang/C17289389/2017-12-05	A/Env/Guangdong/JieyangC17289389/20171205
+A/Env/Guangdong/Jieyang/C17289390/2017-12-05	A/Env/Guangdong/JieyangC17289390/20171205
+A/Env/Guangdong/zhanjiang/C18277136/2018-04-02	A/Env/Guangdong/zhanjiangC18277136/20180402
+A/Env/Guangdong/Foshan/C182750085/2018-01-30	A/Env/Guangdong/FoshanC182750085/20180130
+A/Env/Guangdong/Jieyang/C18289059/2018-02-06	A/Env/Guangdong/JieyangC18289059/20180206
+A/Env/Guangdong/C17059359/YF/2017-05-31	A/Env/Guangdong/C17059359YF/20170531
+A/Env/Guangdong/C172790853/ZHQ/2017-10-30	A/Env/Guangdong/C172790853ZHQ/20171030
+A/Env/Guangdong/C17285757/QY/2017-11-21	A/Env/Guangdong/C17285757QY/20171121
+A/Env/Guangdong/zhanjiang/C17277335/2017-11-27	A/Env/Guangdong/zhanjiangC17277335/20171127
+A/Env/Guangdong/Shaoguan/C17272470/2018-01-16	A/Env/Guangdong/ShaoguanC17272470/20180116
+A/Env/Guangdong/zhanjiang/C18277135/2018-04-02	A/Env/Guangdong/zhanjiangC18277135/20180402
+A/Env/Guangdong/Foshan/C182750020/2018-01-02	A/Env/Guangdong/FoshanC182750020/20180102
+A/Duck/Guangdong/PO1707260017/GZH/2017-08-02	A/Duck/Guangdong/PO1707260017GZH/20170802
+A/Env/Guangdong/Zhaoqing/C172790995/2017-12-12	A/Env/Guangdong/ZhaoqingC172790995/20171212
+A/Env/Guangdong/C17059521/YF/2017-11-14	A/Env/Guangdong/C17059521YF/20171114
+A/Env/Guangdong/EN17275405/FSH/2017-10-18	A/Env/Guangdong/EN17275405FSH/20171018
+A/Env/Guangdong/C17285752/QY/2017-11-21	A/Env/Guangdong/C17285752QY/20171121
+A/Env/Guangdong/C17285753/QY/2017-11-21	A/Env/Guangdong/C17285753QY/20171121
+A/Env/Guangdong/zhongshan/C172870590/2017-11-28	A/Env/Guangdong/zhongshanC172870590/20171128
+A/Duck/Guangdong/Yangjiang/PO18284009/2018-01-09	A/Duck/Guangdong/YangjiangPO18284009/20180109
+A/Env/Guangdong/C172790591/ZHQ/2017-5-8	A/Env/Guangdong/C172790591ZHQ/201758
+A/Env/Guangdong/C172811482/MZH/2017-10-16	A/Env/Guangdong/C172811482MZH/20171016
+A/Goose/Guangdong/PO1707260055/GZH/2017-08-02	A/Goose/Guangdong/PO1707260055GZH/20170802
+A/Env/Guangdong/C17272335/SHG/2017-5-16	A/Env/Guangdong/C17272335SHG/2017516
+A/Env/Guangdong/C17285091/QY/2017-1-17	A/Env/Guangdong/C17285091QY/2017117
+A/Waterfowl/Guangdong/PO17284158/YJ/2017-5-10	A/Waterfowl/Guangdong/PO17284158YJ/2017510
+A/Env/Guangdong/EN17284259/YJ/2017-7-12	A/Env/Guangdong/EN17284259YJ/2017712
+A/Duck/Guangdong/PO17284260/YJ/2017-7-12	A/Duck/Guangdong/PO17284260YJ/2017712
+A/Env/Guangdong/C17280709/HZH/2017-5-2	A/Env/Guangdong/C17280709HZH/201752
+A/Peregrine falcon/Sweden/SVA201117SZ0467/20KN003345/2020	A/Peregrinefalcon/Sweden/SVA201117SZ046720KN003345/2020
+A/barnacle goose/Sweden/SVA201117SZ0468/KN003355/2020	A/barnaclegoose/Sweden/SVA201117SZ0468KN003355/2020
+A/northern goshawk/Sweden/SVA210316SZ0489/KN001044/M/2021	A/northerngoshawk/Sweden/SVA210316SZ0489KN001044M/2021
+A/Canada Goose/Sweden/SVA210330SZ0426/FB001307/E-2021	A/CanadaGoose/Sweden/SVA210330SZ0426FB001307/E2021
+A/greylag goose /Sweden/SVA211103SZ0398/FB004410/M-2021	A/greylaggoose/Sweden/SVA211103SZ0398FB004410/M2021
+A/common pheasant /Sweden/SVA211104SZ0320/FB004417/M-2021	A/commonpheasant/Sweden/SVA211104SZ0320FB004417/M2021
+A/Greylag goose/Sweden/SVA220308SZ0382/FB000559/M-2022	A/Greylaggoose/Sweden/SVA220308SZ0382FB000559/M2022
+A/chicken/CentralJava/Solo/VSN331/2013	A/chicken/CentralJava/SoloVSN331/2013
+A/Greylag goose/Sweden/SVA210209SZ0422/KN000346/2021	A/Greylaggoose/Sweden/SVA210209SZ0422KN000346/2021
+A/Canada goose/Sweden/SVA210209SZ0420/KN000345/2021	A/Canadagoose/Sweden/SVA210209SZ0420KN000345/2021
+A/barnacle goose/Sweden/SVA210202SZ0453/KN000276/2021	A/barnaclegoose/Sweden/SVA210202SZ0453KN000276/2021
+A/barnacle goose/Sweden/SVA210126SZ0462/KN000202/2021	A/barnaclegoose/Sweden/SVA210126SZ0462KN000202/2021
+A/Turkey/Sweden/SVA201118SZ0002/KN305633-IP1/2020	A/Turkey/Sweden/SVA201118SZ0002KN305633IP1/2020
+A/Common buzzard/Sweden/SVA210212SZ0284/KN000390/2021	A/Commonbuzzard/Sweden/SVA210212SZ0284KN000390/2021
+A/northern goshawk/Sweden/SVA210316SZ0489/KN001045/M/2021	A/northerngoshawk/Sweden/SVA210316SZ0489KN001045M/2021
+A/common golden eye/Sweden/SVA210316SZ0489/KN001046/M/2021	A/commongoldeneye/Sweden/SVA210316SZ0489KN001046M/2021
+A/northern goshawk/Sweden/SVA210318SZ0322/KN001092/M/2021	A/northerngoshawk/Sweden/SVA210318SZ0322KN001092M/2021
+A/whooper swan/Sweden/SVA210331SZ0441/FB0001325/W-2021	A/whooperswan/Sweden/SVA210331SZ0441FB0001325/W2021
+A/common pheasant /Sweden/SVA211104SZ0320/FB004418/M-2021	A/commonpheasant/Sweden/SVA211104SZ0320FB004418/M2021
+A/common buzzard /Sweden/SVA211104SZ0320/FB004419/M-2021	A/commonbuzzard/Sweden/SVA211104SZ0320FB004419/M2021
+A/great black-backed gull/Sweden/SVA211109SZ0434/FB004445/M-2021	A/greatblackbackedgull/Sweden/SVA211109SZ0434FB004445/M2021
+A/Chicken/Sweden/SVA211130SZ0427/FB290424-IP-1/M-2021	A/Chicken/Sweden/SVA211130SZ0427FB290424IP1/M2021
+A/Turkey/Sweden/SVA211212SZ0001/FB301013-IP-2/M-2021	A/Turkey/Sweden/SVA211212SZ0001FB301013IP2/M2021
+A/goose/Italy/Italy/21VIR10458/2021	A/goose/Italy/Italy21VIR10458/2021
+A/Canada goose/Sweden/SVA210331SZ/FB001326/W-2021	A/Canadagoose/Sweden/SVA210331SZFB001326/W2021
+A/Canada goose/Sweden/SVA210407SZ0510/FB001379/O-2021	A/Canadagoose/Sweden/SVA210407SZ0510FB001379/O2021
+A/MDCK/Germany/[A/cygnus cygnus/Germany/R65/2006]-P18-escape/2008 (H5N1)	A/MDCK/Germany/[AcygnuscygnusGermanyR652006]P18escape/2008(H5N1)
+A/MDCK/Germany/[A/cygnus cygnus/Germany/R65/2006]-P30-escape/2008 (H5N1)	A/MDCK/Germany/[AcygnuscygnusGermanyR652006]P30escape/2008(H5N1)
+A/MDCK/Germany/[A/cygnus cygnus/Germany/R65/2006]-P50-escape/2008 (H5N1)	A/MDCK/Germany/[AcygnuscygnusGermanyR652006]P50escape/2008(H5N1)
+A/MDCK/Germany/[A/cygnus cygnus/Germany/R65/2006]-P100b-escape/2009 (H5N1)	A/MDCK/Germany/[AcygnuscygnusGermanyR652006]P100bescape/2009(H5N1)
+A/MDCK/Germany/[A/cygnus cygnus/Germany/R65/2006]-PP100b-escape/2009 (H5N1)	A/MDCK/Germany/[AcygnuscygnusGermanyR652006]PP100bescape/2009(H5N1)
+A/MDCK/Germany/[A/cygnus cygnus/Germany/R65/2006]-PP100c-escape/2009 (H5N1)	A/MDCK/Germany/[AcygnuscygnusGermanyR652006]PP100cescape/2009(H5N1)
+A/MDCK/Germany/[A/cygnus cygnus/Germany/R65/2006]-P100c-escape/2009 (H5N1)	A/MDCK/Germany/[AcygnuscygnusGermanyR652006]P100cescape/2009(H5N1)
+A/MDCK/Germany/[A/cygnus cygnus/Germany/R65/2006]-CoP100-control/2009 (H5N1)	A/MDCK/Germany/[AcygnuscygnusGermanyR652006]CoP100control/2009(H5N1)
+A/MDCK/Germany/[A/cygnus cygnus/Germany/R65/2006]-CoP50-control/2008 (H5N1)	A/MDCK/Germany/[AcygnuscygnusGermanyR652006]CoP50control/2008(H5N1)
+A/MDCK/Germany/[A/cygnus cygnus/Germany/R65/2006]-Q18-escape/2009 (H5N1)	A/MDCK/Germany/[AcygnuscygnusGermanyR652006]Q18escape/2009(H5N1)
+A/MDCK/Germany/[A/cygnus cygnus/Germany/R65/2006]-Q30-escape/2009 (H5N1)	A/MDCK/Germany/[AcygnuscygnusGermanyR652006]Q30escape/2009(H5N1)
+A/MDCK/Germany/[A/cygnus cygnus/Germany/R65/2006]-Q50-escape/2009 (H5N1)	A/MDCK/Germany/[AcygnuscygnusGermanyR652006]Q50escape/2009(H5N1)
+A/MDCK/Germany/[A/cygnus cygnus/Germany/R65/2006]-Q100b-escape/2009 (H5N1)	A/MDCK/Germany/[AcygnuscygnusGermanyR652006]Q100bescape/2009(H5N1)
+A/MDCK/Germany/[A/cygnus cygnus/Germany/R65/2006]-QQ100b-escape/2009 (H5N1)	A/MDCK/Germany/[AcygnuscygnusGermanyR652006]QQ100bescape/2009(H5N1)
+A/MDCK/Germany/[A/cygnus cygnus/Germany/R65/2006]-QQ100a-escape/2009 (H5N1)	A/MDCK/Germany/[AcygnuscygnusGermanyR652006]QQ100aescape/2009(H5N1)
+A/MDCK/Germany/[A/cygnus cygnus/Germany/R65/2006]-Q100c-escape/2009 (H5N1)	A/MDCK/Germany/[AcygnuscygnusGermanyR652006]Q100cescape/2009(H5N1)
+A/MDCK/Germany/[A/cygnus cygnus/Germany/R65/2006]-CoQ100-control/2009 (H5N1)	A/MDCK/Germany/[AcygnuscygnusGermanyR652006]CoQ100control/2009(H5N1)
+A/MDCK/Germany/[A/cygnus cygnus/Germany/R65/2006]-CoQ50-control/2009 (H5N1)	A/MDCK/Germany/[AcygnuscygnusGermanyR652006]CoQ50control/2009(H5N1)
+A/duck/Quang/Nam/AI316/2014	A/duck/Quang/NamAI316/2014
+A/Chicken/Sweden/SVA210308SZ0214/KN057720-IP13/2021	A/Chicken/Sweden/SVA210308SZ0214KN057720IP13/2021
+A/Towny owel/Sweden/SVAU210406SZ0042/KN001362/M-2021	A/Townyowel/Sweden/SVAU210406SZ0042KN001362/M2021
+A/common eider/Sweden/SVA210617SZ0354/FB002253/I-2021	A/commoneider/Sweden/SVA210617SZ0354FB002253/I2021
+A/peregrine falcon/Sweden/SVA210309SZ0403/FB000851/K-2021	A/peregrinefalcon/Sweden/SVA210309SZ0403FB000851/K2021
+A/Mute Swan/Sweden/SVA210330SZ0417/FB001305/D-2021	A/MuteSwan/Sweden/SVA210330SZ0417FB001305/D2021
+A/Mallard/Sweden/SVA210827SZ0252/KN002973/D-2021	A/Mallard/Sweden/SVA210827SZ0252KN002973/D2021
+A/Mallard/Sweden/SVA210827SZ0252/KN002974/D-2021	A/Mallard/Sweden/SVA210827SZ0252KN002974/D2021
+A/duck/Vietnam/NCVD1584/2012 NIBRG-301 (18/134)	A/duck/Vietnam/NCVD15842012NIBRG301(18/134)
+A/common buzzard/Sweden/SVA210510SZ0206/FB001829/C-2021	A/commonbuzzard/Sweden/SVA210510SZ0206FB001829/C2021
+A/turkey/Egypt/Cairo/AH/2019	A/turkey/Egypt/CairoAH/2019
+A/Chicken/Madiun/BBVW/1420/2005	A/Chicken/Madiun/BBVW1420/2005
+A/Chicken/West Java/SMI/CSLK-EB/2006	A/Chicken/WestJava/SMICSLKEB/2006
+A/Turkey/Turkey/Kars/09rs2841-42/2006	A/Turkey/Turkey/Kars09rs284142/2006
+A/Turkey/Turkey/Konya/09rs2841-84/2006	A/Turkey/Turkey/Konya09rs284184/2006
+A/Turkey/Turkey/Batman/09rs2841-120/2006	A/Turkey/Turkey/Batman09rs2841120/2006
+A/Turkey/Turkey/Diyarbakir/09rs2842-93/2007	A/Turkey/Turkey/Diyarbakir09rs284293/2007
+A/Turkey/Turkey/Batman/09rs2842-107/2007	A/Turkey/Turkey/Batman09rs2842107/2007
+A/Turkey/Turkey/Batman/09rs2842-110/2007	A/Turkey/Turkey/Batman09rs2842110/2007
+A/Duck/Egypt/FAO/SI2/2017	A/Duck/Egypt/FAOSI2/2017
+A/barnacle goose/Sweden/SVA210423SZ0250/FB001648/M-2021	A/barnaclegoose/Sweden/SVA210423SZ0250FB001648/M2021
+A/barnacle goose/Sweden/SVA210423SZ0252/FB001647/M2021	A/barnaclegoose/Sweden/SVA210423SZ0252FB001647/M2021
+A/barnacle goose/Sweden/SVA210210SZ0372/FB000374/M-2021	A/barnaclegoose/Sweden/SVA210210SZ0372FB000374/M2021
+A/common buzzard/Sweden/SVA210329SZ0208/FB0001278/M-2021	A/commonbuzzard/Sweden/SVA210329SZ0208FB0001278/M2021
+A/peregrine falcon/Sweden/SVA210325SZ0348/FP001210/H-2021	A/peregrinefalcon/Sweden/SVA210325SZ0348FP001210/H2021
+A/Greylag goose/Sweden/SVA210324SZ0403/FB001169/N-2021	A/Greylaggoose/Sweden/SVA210324SZ0403FB001169/N2021
+A/chicken/Egypt/Army/1201/2022	A/chicken/Egypt/Army1201/2022
+A/Wildbirds Guineafowl Makou Egyptian Geese/South Africa/S2017/08 0275 P1/2017	A/WildbirdsGuineafowlMakouEgyptianGeese/SouthAfrica/S2017080275P1/2017
+A/Chicken/Sweden/SVA210301SZ0001/KN049780-IP10/2021	A/Chicken/Sweden/SVA210301SZ0001KN049780IP10/2021
+A/goose/Sweden/SVA210301SZ0005/KN049802-IP11/2021	A/goose/Sweden/SVA210301SZ0005KN049802IP11/2021
+A/barnacle goose/Sweden/SVA210511SZ0567/FB001840/M-2021	A/barnaclegoose/Sweden/SVA210511SZ0567FB001840/M2021
+A/chicken/Bulgaria/Dobrich/12-2/2018	A/chicken/Bulgaria/Dobrich122/2018
+A/chicken/Bulgaria/Plovdiv/224-1/2018	A/chicken/Bulgaria/Plovdiv2241/2018
+A/chicken/Bulgaria/Plovdiv/224-2/2018	A/chicken/Bulgaria/Plovdiv2242/2018
+A/chicken/Bulgaria/Plovdiv/224-3/2018	A/chicken/Bulgaria/Plovdiv2243/2018
+A/chicken/Bulgaria/Haskovo/411/2017	A/chicken/Bulgaria/Haskovo411/2017
+A/chicken/Bulgaria/Sliven/432/2017	A/chicken/Bulgaria/Sliven432/2017
+A/duck/Bulgaria/Dobrich/407/2017	A/duck/Bulgaria/Dobrich407/2017
+A/duck/Bulgaria/Yambol/436/2017	A/duck/Bulgaria/Yambol436/2017
+A/duck/Bulgaria/Stara-Zagora/623/2017	A/duck/Bulgaria/StaraZagora623/2017
+A/duck/Bulgaria/Yambol/35-1/2018	A/duck/Bulgaria/Yambol351/2018
+A/partridge/Bulgaria/Plovdiv/60-1/2018	A/partridge/Bulgaria/Plovdiv601/2018
+A/partridge/Bulgaria/Plovdiv/60-2/2018	A/partridge/Bulgaria/Plovdiv602/2018
+A/duck/Bulgaria/Plovdiv/76-1/2018	A/duck/Bulgaria/Plovdiv761/2018
+A/duck/Bulgaria/Plovdiv/76-2/2018	A/duck/Bulgaria/Plovdiv762/2018
+A/chicken/Bulgaria/Dobrich/115/2018	A/chicken/Bulgaria/Dobrich115/2018
+A/chicken/Bulgaria/Plovdiv/333/2018	A/chicken/Bulgaria/Plovdiv333/2018
+A/turkey/Bulgaria/Haskovo/336/2018	A/turkey/Bulgaria/Haskovo336/2018
+A/duck/Bulgaria/Plovdiv/74-1/2018	A/duck/Bulgaria/Plovdiv741/2018
+A/chicken/Bulgaria/Vidin-Kosovo/550/2018	A/chicken/Bulgaria/VidinKosovo550/2018
+A/duck/Niigata/151103/1/2020	A/duck/Niigata/1511031/2020
+A/duck/Niigata/151103/2/2020	A/duck/Niigata/1511032/2020
+A/Chicken/Sweden/SVA210121SZ0033/KN000273-IP3/2021	A/Chicken/Sweden/SVA210121SZ0033KN000273IP3/2021
+A/Chicken/Sweden/SVA210117SZ0004/KN011326-IP3/2021	A/Chicken/Sweden/SVA210117SZ0004KN011326IP3/2021
+A/Chicken/Sweden/SVA210302SZ0564/KN052345-IP12/2021	A/Chicken/Sweden/SVA210302SZ0564KN052345IP12/2021
+A/Chichen/Sweden/SVA210313SZ0001/KN066654-IP15/2021	A/Chichen/Sweden/SVA210313SZ0001KN066654IP15/2021
+A/Chicken/Sweden/SVA210313SZ0003/KN066666-IP16/2021	A/Chicken/Sweden/SVA210313SZ0003KN066666IP16/2021
+A/common buzzard/Sweden/SVA210415SZ0338/FB001522/O-2021	A/commonbuzzard/Sweden/SVA210415SZ0338FB001522/O2021
+A/whooper swan/Sweden/SVA210420SZ0485/FB0001581/W-2021	A/whooperswan/Sweden/SVA210420SZ0485FB0001581/W2021
+A/muscovy/duck/Hunan/101/2014	A/muscovy/duck/Hunan101/2014
+A/muscovy/duck/Hunan/102/2014	A/muscovy/duck/Hunan102/2014
+A/muscovy/duck/Hunan/103/2014	A/muscovy/duck/Hunan103/2014
+A/muscovy/duck/Hunan/104/2014	A/muscovy/duck/Hunan104/2014
+A/muscovy/duck/Hunan/125/2014	A/muscovy/duck/Hunan125/2014
+A/muscovy/duck/Hunan/147/2014	A/muscovy/duck/Hunan147/2014
+A/muscovy/duck/Hunan/148/2014	A/muscovy/duck/Hunan148/2014
+A/muscovy/duck/Hunan/167/2014	A/muscovy/duck/Hunan167/2014
+A/muscovy/duck/Hunan/183/2014	A/muscovy/duck/Hunan183/2014
+A/muscovy/duck/Hunan/202/2014	A/muscovy/duck/Hunan202/2014
+A/muscovy/duck/Hunan/216/2014	A/muscovy/duck/Hunan216/2014
+A/muscovy/duck/Hunan/229/2014	A/muscovy/duck/Hunan229/2014
+A/muscovy/duck/Hunan/232/2014	A/muscovy/duck/Hunan232/2014
+A/muscovy/duck/Hunan/85/2014	A/muscovy/duck/Hunan85/2014
+A/muscovy/duck/Hunan/88/2014	A/muscovy/duck/Hunan88/2014
+A/muscovy/duck/Hunan/89/2014	A/muscovy/duck/Hunan89/2014
+A/muscovy/duck/Hunan/90/2014	A/muscovy/duck/Hunan90/2014
+A/muscovy/duck/Hunan/93/2014	A/muscovy/duck/Hunan93/2014
+A/muscovy/duck/Hunan/94/2014	A/muscovy/duck/Hunan94/2014
+A/muscovy/duck/Hunan/HN346/2015	A/muscovy/duck/HunanHN346/2015
+A/muscovy/duck/Hunan/HN347/2015	A/muscovy/duck/HunanHN347/2015
+A/muscovy/duck/Hunan/HN348/2015	A/muscovy/duck/HunanHN348/2015
+A/muscovy/duck/Hunan/HN349/2015	A/muscovy/duck/HunanHN349/2015
+A/muscovy/duck/Hunan/HN350/2015	A/muscovy/duck/HunanHN350/2015
+A/muscovy/duck/Hunan/HN351/2015	A/muscovy/duck/HunanHN351/2015
+A/muscovy/duck/Hunan/HN352/2015	A/muscovy/duck/HunanHN352/2015
+A/muscovy/duck/Hunan/HN353/2015	A/muscovy/duck/HunanHN353/2015
+A/muscovy/duck/Hunan/HN354/2015	A/muscovy/duck/HunanHN354/2015
+A/muscovy/duck/Hunan/HN355/2015	A/muscovy/duck/HunanHN355/2015
+A/muscovy/duck/Hunan/HN356/2015	A/muscovy/duck/HunanHN356/2015
+A/muscovy/duck/Hunan/HN358/2015	A/muscovy/duck/HunanHN358/2015
+A/muscovy/duck/Hunan/HN359/2015	A/muscovy/duck/HunanHN359/2015
+A/muscovy/duck/Hunan/HN360/2015	A/muscovy/duck/HunanHN360/2015
+A/muscovy/duck/Hunan/HN364/2015	A/muscovy/duck/HunanHN364/2015
+A/muscovy/duck/Hunan/HN365/2015	A/muscovy/duck/HunanHN365/2015
+A/muscovy/duck/Hunan/HN366/2015	A/muscovy/duck/HunanHN366/2015
+A/muscovy/duck/Hunan/HN368/2015	A/muscovy/duck/HunanHN368/2015
+A/UNL/HK/2:6/2017 (reassortant 2:6 A/Common tern/Uvs-Nuur Lake/26/2016 x A/Hong Kong/1/1968/162/35)	A/UNL/HK/2:62017(reassortant2:6ACommonternUvsNuurLake262016xAHongKong11968162/35)
+A/UNL/HK/2:6/2017 (reassortant 2:6 A/Common tern/Uvs-Nuur Lake/26/2016 x A/Hong Kong/1/1968/162/35)	A/UNL/HK/2:62017(reassortant2:6ACommonternUvsNuurLake262016xAHongKong11968162/35)
+A/chicken/Bulgaria/Dobrich/163-1/2018	A/chicken/Bulgaria/Dobrich1631/2018
+A/chicken/Bulgaria/Dobrich/163-2/2018	A/chicken/Bulgaria/Dobrich1632/2018
+A/chicken/Bulgaria/Haskovo/286/2018	A/chicken/Bulgaria/Haskovo286/2018
+A/chicken/Bulgaria/Plovdiv/295/2018	A/chicken/Bulgaria/Plovdiv295/2018
+A/common pheasant/Sweden/SVA210224SZ0005/KN000542-IP8/2021	A/commonpheasant/Sweden/SVA210224SZ0005KN000542IP8/2021
+A/northern goshawk/Sweden/SVA210224SZ0431/KN000626/2021	A/northerngoshawk/Sweden/SVA210224SZ0431KN000626/2021
+A/northern goshawk/Sweden/SVA210224SZ0479/KN000627/2021	A/northerngoshawk/Sweden/SVA210224SZ0479KN000627/2021
+A/quail/Quang Ngai/AI/431/2015	A/quail/QuangNgai/AI431/2015
+A/duck/Vietnam/QuangBinh/LBM0818/2016(H5N6)	A/duck/Vietnam/QuangBinhLBM0818/2016(H5N6)
+A/duck/Vietnam/QuangBinh/LBM0908/2016(H5N6)	A/duck/Vietnam/QuangBinhLBM0908/2016(H5N6)
+A/duck/Vietnam/QuangBinh/LBM0909/2016(H5N6)	A/duck/Vietnam/QuangBinhLBM0909/2016(H5N6)
+A/duck/Vietnam/QuangBinh/LBM0911/2016(H5N6)	A/duck/Vietnam/QuangBinhLBM0911/2016(H5N6)
+A/Heron/Vietnam/QuangBinh/LBM0910/2016(H5N6)	A/Heron/Vietnam/QuangBinhLBM0910/2016(H5N6)
+A/common buzzard /Sweden/SVA210224SZ0485/KN000628/2021	A/commonbuzzard/Sweden/SVA210224SZ0485KN000628/2021
+A/northern goshawk/Sweden/SVA210225SZ0302/KN000664/2021	A/northerngoshawk/Sweden/SVA210225SZ0302KN000664/2021
+A/barnacle goose/Sweden/SVA210225SZ0307/KN000666/2021	A/barnaclegoose/Sweden/SVA210225SZ0307KN000666/2021
+A/Chicken/Sweden/SVA210314SZ0001/KN066672-IP17/2021	A/Chicken/Sweden/SVA210314SZ0001KN066672IP17/2021
+A/Chicken/Sweden/SVA210314SZ0002/KN066679-IP18/2021	A/Chicken/Sweden/SVA210314SZ0002KN066679IP18/2021
+A/Common peacock/Sweden/SVA210311SZ0002/KN001568-IP14/2021	A/Commonpeacock/Sweden/SVA210311SZ0002KN001568IP14/2021
+A/Goose/Sweden/SVA210311SZ0003/KN0001570-IP14/2021	A/Goose/Sweden/SVA210311SZ0003KN0001570IP14/2021
+A/Duck/Sweden/SVA210311SZ0004/KN0001570-IP14/2021	A/Duck/Sweden/SVA210311SZ0004KN0001570IP14/2021
+A/Canada goose/Sweden/SVA210302SZ0455/KN000714/SKsim/2021	A/Canadagoose/Sweden/SVA210302SZ0455KN000714SKsim/2021
+A/Mute Swan/Sweden/SVA210302Z0465/KN000716/SOTR/2021	A/MuteSwan/Sweden/SVA210302Z0465KN000716SOTR/2021
+A/cat/Romania/TL/nov/2007	A/cat/Romania/TLnov/2007
+A/chicken/Romania/TL/nov/2007	A/chicken/Romania/TLnov/2007
+A/duck/Nong-Khai/Thailand/KU-56/2007	A/duck/NongKhai/ThailandKU56/2007
+A/duck/Romania/TL/nov/2007	A/duck/Romania/TLnov/2007
+A/water/Dongting Lake/Hunan/5-41/2007	A/water/DongtingLake/Hunan541/2007
+A/goose/Hungary/2823/2/2007	A/goose/Hungary/28232/2007
+A/peacock/Mansehra-Pakistan/NARC-7558/02/2007	A/peacock/MansehraPakistan/NARC755802/2007
+A/turkey/Islamabad-Pakistan/NARC-7871/02/2007	A/turkey/IslamabadPakistan/NARC787102/2007
+A/reassortant/SJ002(chicken/Hong Kong/AP156/2008 x Puerto Rico/8/1934)	A/reassortant/SJ002(chicken/HongKongAP1562008xPuertoRico8/1934)
+A/reassortant/IDCDC RG29(Egypt/N03072/2010 x Puerto Rico/8/1934)	A/reassortant/IDCDCRG29(Egypt/N030722010xPuertoRico8/1934)
+A/barnacle goose/Sweden/SVA201125SZ0472/KN003488/2020	A/barnaclegoose/Sweden/SVA201125SZ0472KN003488/2020
+A/Mute Swan/Sweden/SVA210304SZ0311/KN000739/VG/2021	A/MuteSwan/Sweden/SVA210304SZ0311KN000739VG/2021
+A/Canade goose/Sweden/SVA210304SZ0320/KN000779/SK/2021	A/Canadegoose/Sweden/SVA210304SZ0320KN000779SK/2021
+A/Canada goose/Sweden/SVA210305SZ0255/KN000797/SK/2021	A/Canadagoose/Sweden/SVA210305SZ0255KN000797SK/2021
+A/Mute Swan/Sweden/SVA210303SZ0380/KN000800/St/2021	A/MuteSwan/Sweden/SVA210303SZ0380KN000800St/2021
+A/northern goshawk/Sweden/SVA210303SZ0381/KN000801/JO/2021	A/northerngoshawk/Sweden/SVA210303SZ0381KN000801JO/2021
+A/Mute Swan/Sweden/SVA210303SZ0392/KN000806/Kal/2021	A/MuteSwan/Sweden/SVA210303SZ0392KN000806Kal/2021
+A/White-Tailed Eagle/Sweden/SVA210528SZ0223/KN002027/AB-2021	A/WhiteTailedEagle/Sweden/SVA210528SZ0223KN002027/AB2021
+A/common buzzard/Sweden/SVA210505SZ0374/FB0001789/M-2021	A/commonbuzzard/Sweden/SVA210505SZ0374FB0001789/M2021
+A/whooper swan/Sweden/SVA2100329SZ0210/FB0001277/H-2021	A/whooperswan/Sweden/SVA2100329SZ0210FB0001277/H2021
+A/chicken/Thailand/Kamphaengphet/NIAH6-3- 0006/2005	A/chicken/Thailand/KamphaengphetNIAH630006/2005
+A/chicken/Thailand/Kamphaengphet/NIAH6-3- 0008/2005	A/chicken/Thailand/KamphaengphetNIAH630008/2005
+A/chicken/Thailand/Kamphaengphet/NIAH6-3- 0009/2005	A/chicken/Thailand/KamphaengphetNIAH630009/2005
+A/chicken/Thailand/Kamphaengphet/NIAH6-3- 0010/2005	A/chicken/Thailand/KamphaengphetNIAH630010/2005
+A/quail/Thailand/Nakhon Pathom/QA-161/2005	A/quail/Thailand/NakhonPathomQA161/2005
+A/wild goose/Romania/RO-AI-008/CT/2005	A/wildgoose/Romania/ROAI008CT/2005
+A/hen's egg/Germany/[A/cygnus cygnus/Germany/R65/2006]-EscEgg50A-escape/2009 (H5N1)	A/hen'segg/Germany/[AcygnuscygnusGermanyR652006]EscEgg50Aescape/2009(H5N1)
+A/hen's egg/Germany/[A/cygnus cygnus/Germany/R65/2006]-CoJ50-control/2009 (H5N1)	A/hen'segg/Germany/[AcygnuscygnusGermanyR652006]CoJ50control/2009(H5N1)
+A/common pheasant /Sweden/SVA210923SZ0341/KN000365/M-2021-H5N1	A/commonpheasant/Sweden/SVA210923SZ0341KN000365/M2021H5N1
+A/chicken/Nakhon Sawan/Thailand/CU-39/04	A/chicken/NakhonSawan/ThailandCU39/04
+partial/A/chicken/Phnom Penh/OIE14/2015	A/chicken/PhnomPenh/OIE14/2015
+partial/A/chicken/Phnom Penh/OIE3/2015	A/chicken/PhnomPenh/OIE3/2015
+partial/A/chicken/Phnom Penh/OIE1/2015	A/chicken/PhnomPenh/OIE1/2015
+partial/A/chicken/Phnom Penh/OIE13/2015	A/chicken/PhnomPenh/OIE13/2015
+partial/A/chicken/Takeo/OIE6/2014	A/chicken/TakeoOIE6/2014
+partial/A/duck/Phnom Penh/OIE34/2015	A/duck/PhnomPenh/OIE34/2015
+partial/A/duck/Phnom Penh/OIE40/2015	A/duck/PhnomPenh/OIE40/2015
+partial/A/chicken/Phnom Penh/OIE37/2015	A/chicken/PhnomPenh/OIE37/2015
+partial/A/duck/Kampot/OIE44/2015	A/duck/KampotOIE44/2015
+partial/A/duck/Phnom Penh/OIE30/2015	A/duck/PhnomPenh/OIE30/2015
+partial/A/duck/Phnom Penh/OIE24/2015	A/duck/PhnomPenh/OIE24/2015
+partial/A/chicken/Phnom Penh/OIE10/2015	A/chicken/PhnomPenh/OIE10/2015
+partial/A/chicken/Phnom Penh/OIE17/2015	A/chicken/PhnomPenh/OIE17/2015
+partial/A/chicken/Phnom Penh/OIE18/2015	A/chicken/PhnomPenh/OIE18/2015
+partial/A/chicken/Phnom Penh/OIE20/2015	A/chicken/PhnomPenh/OIE20/2015
+partial/A/chicken/Phnom Penh/OIE35/2015	A/chicken/PhnomPenh/OIE35/2015
+partial/A/chicken/Phnom Penh/OIE36/2015	A/chicken/PhnomPenh/OIE36/2015
+partial/A/chicken/Phnom Penh/OIE39/2015	A/chicken/PhnomPenh/OIE39/2015
+partial/A/chicken/Phnom Penh/OIE8/2015	A/chicken/PhnomPenh/OIE8/2015
+partial/A/duck/Kampot/OIE41/2015	A/duck/KampotOIE41/2015
+partial/A/duck/Kampot/OIE42/2015	A/duck/KampotOIE42/2015
+partial/A/duck/Phnom Penh/OIE10/2015	A/duck/PhnomPenh/OIE10/2015
+partial/A/duck/Phnom Penh/OIE15/2015	A/duck/PhnomPenh/OIE15/2015
+partial/A/duck/Phnom Penh/OIE16/2015	A/duck/PhnomPenh/OIE16/2015
+partial/A/duck/Phnom Penh/OIE17/2015	A/duck/PhnomPenh/OIE17/2015
+partial/A/duck/Phnom Penh/OIE18/2015	A/duck/PhnomPenh/OIE18/2015
+partial/A/duck/Phnom Penh/OIE19/2015	A/duck/PhnomPenh/OIE19/2015
+partial/A/duck/Phnom Penh/OIE20/2015	A/duck/PhnomPenh/OIE20/2015
+partial/A/duck/Phnom Penh/OIE21/2015	A/duck/PhnomPenh/OIE21/2015
+partial/A/duck/Phnom Penh/OIE22/2015	A/duck/PhnomPenh/OIE22/2015
+partial/A/duck/Phnom Penh/OIE23/2015	A/duck/PhnomPenh/OIE23/2015
+partial/A/duck/Phnom Penh/OIE25/2015	A/duck/PhnomPenh/OIE25/2015
+partial/A/duck/Phnom Penh/OIE26/2015	A/duck/PhnomPenh/OIE26/2015
+partial/A/duck/Phnom Penh/OIE27/2015	A/duck/PhnomPenh/OIE27/2015
+partial/A/duck/Phnom Penh/OIE28/2015	A/duck/PhnomPenh/OIE28/2015
+partial/A/duck/Phnom Penh/OIE29/2015	A/duck/PhnomPenh/OIE29/2015
+partial/A/duck/Phnom Penh/OIE48/2015	A/duck/PhnomPenh/OIE48/2015
+partial/A/duck/Phnom Penh/OIE50/2015	A/duck/PhnomPenh/OIE50/2015
+partial/A/duck/Phnom Penh/OIE9/2015	A/duck/PhnomPenh/OIE9/2015
+partial/A/duck/Takeo/OIE16/2015	A/duck/Takeo/OIE16/2015
+partial/A/duck/Takeo/OIE17/2015	A/duck/Takeo/OIE17/2015
+partial/A/duck/Takeo/OIE18/2015	A/duck/Takeo/OIE18/2015
+partial/A/duck/Takeo/OIE46/2015	A/duck/Takeo/OIE46/2015
+partial/A/duck/Takeo/OIE47/2015	A/duck/Takeo/OIE47/2015
+A/Chicken/Sweden/SVA210323SZ001/KN001982-IP21/2021	A/Chicken/Sweden/SVA210323SZ001KN001982IP21/2021
+A/barnacle goose/Sweden/SVA211111SZ0376/FB004496/2021	A/barnaclegoose/Sweden/SVA211111SZ0376FB004496/2021
+A/greylag goose /Sweden/SVA211111SZ0376/FB004497/M-2021	A/greylaggoose/Sweden/SVA211111SZ0376FB004497/M2021
+A/reassortant/IDCDC-RG42A(Sichuan/26221/2014 X Puerto Rico/8/1934)	A/reassortant/IDCDCRG42A(Sichuan/262212014XPuertoRico8/1934)
+A/duck/Vietnam/QuangBinh/DH130723/2017	A/duck/Vietnam/QuangBinhDH130723/2017
+A/duck/Vietnam/QuangBinh/DH330718/2017	A/duck/Vietnam/QuangBinhDH330718/2017
+A/chicken/Vietnam/QuangBinh/BD1113/2017	A/chicken/Vietnam/QuangBinhBD1113/2017
+A/chicken/Vietnam/QuangBinh/BoTrach1113/2017	A/chicken/Vietnam/QuangBinhBoTrach1113/2017
+A/duck/Vietnam/QuangBinh/QN530206/2018	A/duck/Vietnam/QuangBinhQN530206/2018
+A/Chiken/Sweden/SVA210321SZ0001/KN073551-IP20/2021	A/Chiken/Sweden/SVA210321SZ0001KN073551IP20/2021
+A/western marsh harrier/Sweden/SVA210316SZ0486/KN001011/E/2021	A/westernmarshharrier/Sweden/SVA210316SZ0486KN001011E/2021
+A/common eider/Sweden/SVA210729SZ0320/FB002613/I-2021	A/commoneider/Sweden/SVA210729SZ0320FB002613/I2021
+A/common eider/Sweden/SVA210729SZ0323/FB002615/I-2021	A/commoneider/Sweden/SVA210729SZ0323FB002615/I2021
+A/barnacle goose/Sweden/SVA211102SZ0402/FB004395/M-2021	A/barnaclegoose/Sweden/SVA211102SZ0402FB004395/M2021
+A/European herring gull/Sweden/SVA211116SZ0432/FB004518/M-2021	A/Europeanherringgull/Sweden/SVA211116SZ0432FB004518/M2021
+A/greylag goose /Sweden/SVA211118SZ0354/FB004497/I-2021	A/greylaggoose/Sweden/SVA211118SZ0354FB004497/I2021
+A/reassortant/IBCDC-RG7 (chicken/India/NIV33487/2006 x Puerto Rico/8/1934)	A/reassortant/IBCDCRG7(chicken/IndiaNIV334872006xPuertoRico8/1934)
+A/sanderling/MA/22HP00124/2022	A/sanderling/Massachusetts/22HP00124/2022
+A/sanderling/MA/22HP00127/2022	A/sanderling/Massachusetts/22HP00127/2022
+A/sanderling/MA/22HP00130/2022	A/sanderling/Massachusetts/22HP00130/2022
+A/red-tailed hawk/MA/22HP00131/2022	A/red-tailedhawk/Massachusetts/22HP00131/2022
+A/sanderling/MA/22HP00133/2022	A/sanderling/Massachusetts/22HP00133/2022
+A/sanderling/MA/22HP00135/2022	A/sanderling/Massachusetts/22HP00135/2022
+A/herring gull/MA/22HP00137/2022	A/herringgull/Massachusetts/22HP00137/2022
+A/american crow/MA/22HP00148/2022	A/americancrow/Massachusetts/22HP00148/2022
+A/american crow/MA/22HP00149/2022	A/americancrow/Massachusetts/22HP00149/2022
+A/american crow/MA/22HP00150/2022	A/americancrow/Massachusetts/22HP00150/2022
+A/sanderling/MA/22HP00159/2022	A/sanderling/Massachusetts/22HP00159/2022
+A/american crow/MA/22HP00185/2022	A/americancrow/Massachusetts/22HP00185/2022
+A/sanderling/MA/22HP00191/2022	A/sanderling/Massachusetts/22HP00191/2022
+A/sanderling/MA/22HP00192/2022	A/sanderling/Massachusetts/22HP00192/2022
+A/great horned owl/MA/22MM00199/2022	A/greathornedowl/Massachusetts/22MM00199/2022
+A/common eider/MA/22MM00763/2022	A/commoneider/Massachusetts/22MM00763/2022
+A/common_tern/ME/COTE_20220612_1/2022	A/commontern/Maine/COTE202206121/2022
+A/common_tern/ME/COTE_20220614_1/2022	A/commontern/Maine/COTE202206141/2022
+A/common_tern/ME/COTE_20220614_2/2022	A/commontern/Maine/COTE202206142/2022
+A/red-tailed hawk/MA/22MM00791/2022	A/red-tailedhawk/Massachusetts/22MM00791/2022
+A/red-tailed hawk/MA/22MM00792/2022	A/red-tailedhawk/Massachusetts/22MM00792/2022
+A/great_black-backed_gull/MA/GBBG_0220615_1/2022	A/greatblack-backedgull/Massachusetts/GBBG202206151/2022
+A/great black-backed gull/MA/22MM00822/2022	A/greatblack-backedgull/Massachusetts/22MM00822/2022
+A/peregrine falcon/MA/22MM00756/2022	A/peregrinefalcon/Massachusetts/22MM00756/2022
+A/peregrine falcon/MA/22MM00802/2022	A/peregrinefalcon/Massachusetts/22MM00802/2022
+A/red-tailed hawk/MA/22HP00157/2022	A/red-tailedhawk/Massachusetts/22HP00157/2022
+A/american crow/MA/22HP00160/2022	A/americancrow/Massachusetts/22HP00160/2022
+A/snowy owl/MA/22MM00323/2022	A/snowyowl/Massachusetts/22MM00323/2022
+A/snowy owl/MA/22MM00463/2022	A/snowyowl/Massachusetts/22MM00463/2022
+A/snowy owl/MA/22MM00467/2022	A/snowyowl/Massachusetts/22MM00467/2022
+A/northern gannet/MA/22WI00050/2022	A/northerngannet/Massachusetts/22WI00050/2022
 

--- a/source-data/geo_regions.tsv
+++ b/source-data/geo_regions.tsv
@@ -35,6 +35,7 @@ mauritania	africa
 mauritius	africa
 mayotte	africa
 mozambique	africa
+namibia	africa
 niger	africa
 nigeria	africa
 reunion	africa
@@ -66,6 +67,7 @@ france	europe
 germany	europe
 gibraltar	europe
 greece	europe
+greenland	europe
 hungary	europe
 iceland	europe
 ireland	europe

--- a/source-data/geo_synonyms.tsv
+++ b/source-data/geo_synonyms.tsv
@@ -838,6 +838,7 @@ Congo	Congo	Congo	Congo
 
 # DemocraticRepublicofCongo
 DemocraticRepublicOfCongo	DemocraticRepublicOfCongo	DemocraticRepublicOfCongo	DemocraticRepublicOfCongo
+TheDemocraticRepublicoftheCongo	DemocraticRepublicOfCongo	DemocraticRepublicOfCongo	DemocraticRepublicOfCongo
 
 # Denmark
 Denmark	Denmark	Denmark	Denmark
@@ -1180,6 +1181,9 @@ Volos	Greece	Thessaly	Volos
 Vonitsa	Greece	WesternGreece	Vonitsa
 Xanthi	Greece	EasternMacedoniaAndThrace	Xanthi
 Zakynthos	Greece	IonianIslands	Zakynthos
+
+# Greenland
+Greenland	Greenland	Greenland	Greenland
 
 # Grenada
 Grenada	Grenada	Grenada	Grenada
@@ -1930,6 +1934,7 @@ Puertovallartajalisco	Mexico	Jalisco	PuertoVallarta
 Cdvictoriatamaulipas	Mexico	Tamaulipas	CiudadVictoria
 Veracruz	Mexico	Veracruz	Veracruz
 Tabasco	Mexico	Tabasco	Tabasco
+Durango	Mexico	Durango	Durango
 
 # Micronesia
 MicronesiaFederatedStatesOf	Micronesia	Micronesia	Micronesia
@@ -2023,6 +2028,9 @@ Shan	Myanmar	Shan	Shan
 Thanatpin	Myanmar	Bago	Thanatpin
 Yinmarbin	Myanmar	Sagaing	Yinmarbin
 Pyigyitagon	Myanmar	Mandalay	Pyigyitagon
+
+# Namibia
+Namibia	Namibia	Namibia	Namibia
 
 # Nauru
 Nauru	Nauru	Nauru	Nauru
@@ -2376,6 +2384,7 @@ Buryatia	Russia	Buryatia	Buryatia
 Buturlinovka	Russia	Voronezh	Buturlinovka
 Chany	Russia	Novosibirsk	Chany
 Cheboksary	Russia	Chuvash	Cheboksary
+Chechnya	Russia	Chechnya	Chechnya
 Chelyabinsk	Russia	Chelyabinsk	Chelyabinsk
 Cherepovets	Russia	Vologda	Cherepovets
 Cherkessk	Russia	Karachay-Cherkess	Cherkessk
@@ -3386,6 +3395,7 @@ Kansas	USA	Kansas	Kansas
 Lackland	USA	Texas	Lackland
 LosAngeles	USA	California	LosAngeles
 Keywestfl	USA	Florida	KeyWest
+Maine	USA	Maine	Maine
 Mayoclinic	USA	Minnesota	Mayoclinic
 Minneapolis	USA	Minnesota	Minneapolis
 Memphis	USA	Tennessee	Memphis
@@ -3473,6 +3483,7 @@ Mekongdelta	Vietnam	MekongDelta	MekongDelta
 MongCai	Vietnam	QuangNinh	MongCai
 NamDinh	Vietnam	NamDinh	NamDinh
 NgheAn	Vietnam	NgheAn	NgheAn
+NhaTrang	Vietnam	KhanhHoa	NhaTrang
 NinhBinh	Vietnam	NinhBinh	NinhBinh
 PhuTho	Vietnam	PhuTho	PhuTho
 QuangNinh	Vietnam	QuangNinh	QuangNinh


### PR DESCRIPTION
### Description of proposed changes

This pull request includes a series of simple changes to the avian-flu upload protocol to account for a few new features: 

1. GISAID recently began including clade information into the downloadable metadata. This is useful information to download, especially because it includes up to date clade 2.3.4.4 and 2.3.2.1 splits. This pull request includes new download and upload fields for fauna. 

2. I've separated out the strain name fixes into their own file that is distinct from the seasonal flu strain name fixes. The file was getting enormous, and there are some very specific, recurrent errors in the avian flu database that are just easier to deal with on their own. Avian flu strain name fixes are now included in `avian_flu_strain_name_fix.tsv`.

3. I also added a check to print out strains that have too many partitions. This is a pretty common occurrence in the avian flu data, where data submitters will include extra information in the strain name as extra partitions. This messes up the host and country parsing. I wrote a small check to print out these strain names so that they can be added to `avian_flu_strain_name_fix.tsv`

### Testing
I tested this out in `test_vdb` with a series of increasingly larger uploads. To incorporate the GISAID clade field into existing data, I re-downloaded all available H5Nx sequences uploaded from 1996 to today, and tested their upload in `test_vdb`. After confirming that the fields were appropriately parsed and uploaded into `test_vdb`, I uploaded to `vdb` and confirmed that the new clade field had been properly added. 
