### PR TITLE
Delete records with date intervals

### DIFF
--- a/scripts/delete_records.py
+++ b/scripts/delete_records.py
@@ -25,15 +25,19 @@ if __name__ == "__main__":
         key, value = delete_filter.split(':')
         delete_filters[key] = value
 
-    print(delete_filters)
+    print(f"Delete filters: {delete_filters}")
 
     rethinkdb_command = r.table(args.virus).filter(delete_filters)
 
+    delete_intervals = {}
     for interval in args.interval:
         field, values = interval.split(':')
         older_date, newer_date = values.split(',')
         rethinkdb_command = rethinkdb_command.filter(lambda doc: rethinkdb_date_greater(doc[field].split('-'), older_date.split('-'), relaxed_interval=False))
         rethinkdb_command = rethinkdb_command.filter(lambda doc: rethinkdb_date_greater(newer_date.split('-'), doc[field].split('-'), relaxed_interval=False))
+        delete_intervals[field] = (older_date, newer_date)
+
+    print(f"Delete intervals: {delete_intervals}")
 
     if args.preview:
         filtered_records = rethinkdb_command.run()

--- a/scripts/delete_records.py
+++ b/scripts/delete_records.py
@@ -10,8 +10,8 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("-db", "--database", help="database to delete from")
     parser.add_argument("-v", "--virus", default="flu", help="virus table to interact with")
-    parser.add_argument("--filter", nargs="*", help="Filters for records to delete, i.e. inclusion_date: 2021-02-12")
-    parser.add_argument('--interval', nargs="*", help="Select date interval of values for fields, e.g. assay_date:2019-09-03,2023-10-25")
+    parser.add_argument("--filter", nargs="*", default=[], help="Filters for records to delete, i.e. inclusion_date: 2021-02-12")
+    parser.add_argument('--interval', nargs="*", default=[], help="Select date interval of values for fields, e.g. assay_date:2019-09-03,2023-10-25")
     parser.add_argument("--preview", action="store_true", help="Preview records to be deleted without deleting from db.")
 
     args = parser.parse_args()

--- a/scripts/delete_records.py
+++ b/scripts/delete_records.py
@@ -25,8 +25,10 @@ if __name__ == "__main__":
 
     print(delete_filters)
 
+    rethinkdb_command = r.table(args.virus).filter(delete_filters)
+
     if args.preview:
-        filtered_records = r.table(args.virus).filter(delete_filters).run()
+        filtered_records = rethinkdb_command.run()
         deletion_count = 0
         sources = set()
         for record in filtered_records:
@@ -42,5 +44,5 @@ if __name__ == "__main__":
         print("Preview: selection would delete {} records".format(deletion_count))
         print("Sources of deleted records: {}".format(sources))
     else:
-        deleted = r.table(args.virus).filter(delete_filters).delete().run()
+        deleted = rethinkdb_command.delete().run()
         print("Deleted {} records".format(deleted["deleted"]))


### PR DESCRIPTION
## Description of proposed changes

Add a new `--interval` option `delete_records.py` to filter records with date intervals.
This will be used to delete records that uploaded within a certain
date interval in preparation for uploading the latest CDC data¹ and
for merging https://github.com/nextstrain/fauna/pull/131.

Follows the pattern of the `--interval` option for `tdb/download.py` and
uses the `rethinkdb_date_greater` function from `vdb/download.py` to
check for date range in documents.

¹ https://bedfordlab.slack.com/archives/C03KWDET9/p1697750132854499


## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
