### PR TITLE
TLS support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "chateau"]
 	path = chateau
 	url = https://github.com/nextstrain/chateau
+	branch = trs/tls-support

--- a/RETHINKDB.md
+++ b/RETHINKDB.md
@@ -26,6 +26,7 @@ locally, data will be saved after stopping the server and loaded when rebooting 
 
 ```
 from rethinkdb import r
+import certifi
 ```
 
 ### Open connection to rethink database
@@ -36,7 +37,7 @@ r.connect(host='localhost', port=28015, db=database).repl()
 ```
 To open a connection to a database on an external host that requires an authorization key run
 ```
-r.connect(host=rethink_host, port=28015, db=database, auth_key=auth_key).repl()
+r.connect(host=rethink_host, port=28015, db=database, auth_key=auth_key, ssl={"ca_certs":certifi.where()}).repl()
 ```
 
 ### Create new databases and tables

--- a/base/rethink_io.py
+++ b/base/rethink_io.py
@@ -1,5 +1,6 @@
 import datetime, os
 from rethinkdb import r
+import certifi
 
 class rethink_io(object):
     def __init__(self, **kwargs):
@@ -42,7 +43,7 @@ class rethink_io(object):
                 raise Exception("Failed to connect to the database, " + db)
         else:
             try:
-                conn = r.connect(host=rethink_host, port=28015, db=db, auth_key=auth_key).repl()
+                conn = r.connect(host=rethink_host, port=28015, db=db, auth_key=auth_key, ssl={"ca_certs":certifi.where()}).repl()
                 print("Connected to the \"" + db + "\" database")
                 return conn
             except:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 biopython >=1.73, ==1.*
 boto >=2.38, ==2.*
+certifi
 pandas >=1.1.5, ==1.*
 rethinkdb >=2.4.8, ==2.4.*
 requests >=2.20.0, ==2.*


### PR DESCRIPTION
Require TLS on non-localhost connections

We've enabled TLS for Fauna's RethinkDB server.

The rethinkdb Python module requires a set of CA certificates to trust
and cannot be configured to use the system's default set of trusted CAs.
Use certifi to obtain a reasonable default set of commonly trusted CAs.

Related-to: <https://github.com/nextstrain/private/issues/86>

