### PR TITLE
tdb/elife_upload: Update assay_date parsing

### DIFF
--- a/tdb/elife_upload.py
+++ b/tdb/elife_upload.py
@@ -50,7 +50,8 @@ class elife_upload(upload):
             self.format_subtype(meas)
             self.format_assay_type(meas)
             self.format_date(meas)
-            meas['assay_date'] = fstem_assay_date
+            if meas.get('assay_date') is None:
+                meas['assay_date'] = fstem_assay_date
             self.format_passage(meas, 'serum_passage', 'serum_passage_category')
             self.format_passage(meas, 'virus_passage', 'virus_passage_category')
             self.format_ref(meas)

--- a/tdb/elife_upload.py
+++ b/tdb/elife_upload.py
@@ -40,6 +40,7 @@ class elife_upload(upload):
         self.HI_ref_name_abbrev =self.define_strain_fixes(self.HI_ref_name_abbrev_fname)
         self.define_location_label_fixes("source-data/flu_fix_location_label.tsv")
         self.define_countries("source-data/geo_synonyms.tsv")
+        fstem_assay_date = self.parse_assay_date_from_filename(kwargs['fstem'])
         for meas in measurements:
             meas['virus_strain'], meas['original_virus_strain'] = self.fix_name(self.HI_fix_name(meas['virus_strain'], serum=False))
             meas['serum_strain'], meas['original_serum_strain'] = self.fix_name(self.HI_fix_name(meas['serum_strain'], serum=True))
@@ -49,7 +50,7 @@ class elife_upload(upload):
             self.format_subtype(meas)
             self.format_assay_type(meas)
             self.format_date(meas)
-            self.parse_assay_date_from_filename(meas, kwargs['fstem'])
+            meas['assay_date'] = fstem_assay_date
             self.format_passage(meas, 'serum_passage', 'serum_passage_category')
             self.format_passage(meas, 'virus_passage', 'virus_passage_category')
             self.format_ref(meas)
@@ -68,25 +69,26 @@ class elife_upload(upload):
         return measurements
 
 
-    def parse_assay_date_from_filename(self, meas, fstem):
+    def parse_assay_date_from_filename(self, fstem):
         """
         Parse assay date from the *fstem*.
         *fstem* is expected to be formatted as `YYYYMMDD*`
 
-        If unable to parse date from *fstem*, then assay date is masked as `XXXX-XX-XX`.
+        If unable to parse date from *fstem*, then return masked assay date as `XXXX-XX-XX`.
         """
+        assay_date = "XXXX-XX-XX"
         tmp = fstem.split('-')[0]
         if len(tmp) > 8:
             tmp = tmp[:(8-len(tmp))]
         elif len(tmp) < 8:
-            meas['assay_date'] = "XXXX-XX-XX"
+            assay_date = "XXXX-XX-XX"
         else:
             if tmp[0:2] == '20':
-                meas['assay_date'] = "{}-{}-{}".format(tmp[0:4],tmp[4:6],tmp[6:8])
+                assay_date = "{}-{}-{}".format(tmp[0:4],tmp[4:6],tmp[6:8])
             else:
-                meas['assay_date'] = "XXXX-XX-XX"
-        if 'assay_date' not in meas.keys() or meas['assay_date'] is None:
-            meas['assay_date'] = "XXXX-XX-XX"
+                assay_date = "XXXX-XX-XX"
+
+        return assay_date
 
 
     def disambiguate_sources(self, measurements):

--- a/tdb/elife_upload.py
+++ b/tdb/elife_upload.py
@@ -49,18 +49,7 @@ class elife_upload(upload):
             self.format_subtype(meas)
             self.format_assay_type(meas)
             self.format_date(meas)
-            tmp = kwargs['fstem'].split('-')[0]
-            if len(tmp) > 8:
-                tmp = tmp[:(8-len(tmp))]
-            elif len(tmp) < 8:
-                meas['assay_date'] = "XXXX-XX-XX"
-            else:
-                if tmp[0:2] == '20':
-                    meas['assay_date'] = "{}-{}-{}".format(tmp[0:4],tmp[4:6],tmp[6:8])
-                else:
-                    meas['assay_date'] = "XXXX-XX-XX"
-            if 'assay_date' not in meas.keys() or meas['assay_date'] is None:
-                meas['assay_date'] = "XXXX-XX-XX"
+            self.parse_assay_date_from_filename(meas, kwargs['fstem'])
             self.format_passage(meas, 'serum_passage', 'serum_passage_category')
             self.format_passage(meas, 'virus_passage', 'virus_passage_category')
             self.format_ref(meas)
@@ -77,6 +66,28 @@ class elife_upload(upload):
         self.check_strain_names(measurements)
         self.disambiguate_sources(measurements)
         return measurements
+
+
+    def parse_assay_date_from_filename(self, meas, fstem):
+        """
+        Parse assay date from the *fstem*.
+        *fstem* is expected to be formatted as `YYYYMMDD*`
+
+        If unable to parse date from *fstem*, then assay date is masked as `XXXX-XX-XX`.
+        """
+        tmp = fstem.split('-')[0]
+        if len(tmp) > 8:
+            tmp = tmp[:(8-len(tmp))]
+        elif len(tmp) < 8:
+            meas['assay_date'] = "XXXX-XX-XX"
+        else:
+            if tmp[0:2] == '20':
+                meas['assay_date'] = "{}-{}-{}".format(tmp[0:4],tmp[4:6],tmp[6:8])
+            else:
+                meas['assay_date'] = "XXXX-XX-XX"
+        if 'assay_date' not in meas.keys() or meas['assay_date'] is None:
+            meas['assay_date'] = "XXXX-XX-XX"
+
 
     def disambiguate_sources(self, measurements):
         '''


### PR DESCRIPTION
## Description of proposed changes
Updates to the assay date parsing in tdb/elife_upload:
- make parsing of assay date from fstem a little more robust 
- use the fstem's assay date as backup to the date that is in the measurement records. 

Motivated by the [latest discussion on ingesting the VIDRL flat files](https://bedfordlab.slack.com/archives/C03KWDET9/p1699914235686809). 

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
