### PR TITLE
Fix GISAID flu accessions

### DIFF
--- a/vdb/flu_upload.py
+++ b/vdb/flu_upload.py
@@ -209,7 +209,7 @@ class flu_upload(upload):
         for field in ['gender', 'host', 'locus']:
             if field in doc and doc[field] is not None:
                 doc[field] = self.camelcase_to_snakecase(doc[field])
-        if 'accession' in doc and doc['accession'] is not None:
+        if doc.get('accession') is not None and not doc['accession'].startswith('EPI'):
             doc['accession'] = 'EPI' + doc['accession']
 
     def fix_age(self, doc):


### PR DESCRIPTION
## Description of proposed changes

Digging through git history and found example of FASTA header that
suggests GISAID did not used to include the "EPI" prefix in their
DNA Accession no. field.¹

This must have changed around October 2023 because we have sequences
with "EPIEPI" accessions for sequences submitted after September 27th 2023.²

This commit changes the ingest to only prefix with "EPI" if the accession
does not already have the prefix.

¹ https://github.com/nextstrain/fauna/blame/f485baa3621002b3ff6f833c743180239a92bf14/vdb/gisaid_flu_upload.py#L281-L282
² https://bedfordlab.slack.com/archives/C03KWDET9/p1700609695217959

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
