### PR TITLE
requirements: Skip rethinkdb v2.4.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ biopython >=1.73, ==1.*
 boto >=2.38, ==2.*
 certifi
 pandas >=1.1.5, ==1.*
-rethinkdb >=2.4.8, ==2.4.*
+rethinkdb >=2.4.8, ==2.4.*, !=2.4.10
 requests >=2.20.0, ==2.*
 unidecode >=1.0.22, ==1.*
 xlrd >=1.0.0, ==1.*


### PR DESCRIPTION
rethinkdb v2.4.10 is broken because it did not include the newly added `looseversion` package to their setup.py.

https://github.com/rethinkdb/rethinkdb-python/issues/309
