### PR TITLE
vdb/flu_upload: parse `submitting_lab` from XLS

### DIFF
--- a/vdb/flu_upload.py
+++ b/vdb/flu_upload.py
@@ -471,13 +471,14 @@ class flu_upload(upload):
 
 if __name__=="__main__":
     args = parser.parse_args()
-    sequence_fasta_fields = {0: 'accession', 1: 'strain', 2: 'isolate_id', 3:'locus', 4: 'passage', 5: 'submitting_lab'}
+    sequence_fasta_fields = {0: 'accession', 1: 'strain', 2: 'isolate_id', 3:'locus', 4: 'passage'}
     #              >>B/Austria/896531/2016  | EPI_ISL_206054 | 687738 | HA | Siat 1
     setattr(args, 'fasta_fields', sequence_fasta_fields)
     xls_fields_wanted = [('strain', 'Isolate_Name'), ('isolate_id', 'Isolate_Id'), ('collection_date', 'Collection_Date'),
                              ('host', 'Host'), ('Subtype', 'Subtype'), ('Lineage', 'Lineage'),
                              ('gisaid_location', 'Location'), ('originating_lab', 'Originating_Lab'), ('Host_Age', 'Host_Age'),
-                             ('Host_Age_Unit', 'Host_Age_Unit'), ('gender', 'Host_Gender'), ('submission_date', 'Submission_Date')]
+                             ('Host_Age_Unit', 'Host_Age_Unit'), ('gender', 'Host_Gender'), ('submission_date', 'Submission_Date'),
+                             ('submitting_lab', 'Submitting_Lab')]
     setattr(args, 'xls_fields_wanted', xls_fields_wanted)
     if args.path is None:
         args.path = "data/"

--- a/vdb/flu_upload.py
+++ b/vdb/flu_upload.py
@@ -95,6 +95,9 @@ class flu_upload(upload):
                 content = list(map(lambda x: x.strip(), record.description.replace(">", "").split('|')))
                 s = {key: content[ii] if ii < len(content) else "" for ii, key in sequence_fasta_fields.items()}
                 s['sequence'] = str(record.seq)
+                # Exclude the bad submitting lab names due to download bug in GISAID
+                if s.get("submitting_lab", "").lower() == "$ins_submitting_name":
+                    s["submitting_lab"] = ""
                 s = self.add_sequence_fields(s, **kwargs)
                 sequences.append(s)
             handle.close()
@@ -471,7 +474,7 @@ class flu_upload(upload):
 
 if __name__=="__main__":
     args = parser.parse_args()
-    sequence_fasta_fields = {0: 'accession', 1: 'strain', 2: 'isolate_id', 3:'locus', 4: 'passage'}
+    sequence_fasta_fields = {0: 'accession', 1: 'strain', 2: 'isolate_id', 3:'locus', 4: 'passage', 5: 'submitting_lab'}
     #              >>B/Austria/896531/2016  | EPI_ISL_206054 | 687738 | HA | Siat 1
     setattr(args, 'fasta_fields', sequence_fasta_fields)
     xls_fields_wanted = [('strain', 'Isolate_Name'), ('isolate_id', 'Isolate_Id'), ('collection_date', 'Collection_Date'),


### PR DESCRIPTION
CDC folks flagged that our seasonal flu builds¹ contain a weird submitting lab ("$ins Submitting Name") for many sequences.

I found that these values were coming directly from our FASTA headers in the download from GISAID.² This commit changes our flu upload script to parse the submitting lab from the metadata XLS file instead of the FASTA header since the XLS file contains the correct values.

When we download the sequences with `vdb/flu_download`, the `rethinkdb_download` merge command³ will give preference to the `submitting_lab` of the `flu_viruses` table according to the rethinkdb docs.⁴

> When there is a conflict between field names, preference is given to
> fields in the rightmost object in the argument list.

So to correct the existing sequences within fauna, we just need to re-upload the sequences that contain the bad submitting lab name.

¹ https://nextstrain.org/flu/seasonal/h3n2/ha/2y@2024-04-18?f_submitting_lab=%24ins%20Submitting%20Name 
² https://bedfordlab.slack.com/archives/C03KWDET9/p1713806442592619 
³ https://github.com/nextstrain/fauna/blob/8471abf1287004e5dc2af66d80b178abbbfc8d4c/vdb/download.py#L144 
⁴ https://rethinkdb.com/api/python/merge/


<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
