### PR TITLE
adding syntax to check for cattle sequences and add cattle as a disti…

### DIFF
--- a/vdb/avian_flu_upload.py
+++ b/vdb/avian_flu_upload.py
@@ -484,6 +484,7 @@ class flu_upload(upload):
         environment_list = [
             "feces", "otherenvironment", "surfaceswab", "watersample", "environment",
             "airsample"]
+        cattle_list = ["dairycattle","cattle","cow","bovine"]
         nonhuman_mammal_list = [
             "bat", "canine", "equine", "feline", "harbourseal","mammals", "mink", "othermammals",
             "primate","swine","pig", "susscrofadomesticus", "lion", "weasel", "raccoon__dog", "tiger",
@@ -497,8 +498,18 @@ class flu_upload(upload):
                 v['host'] = "avian"
             elif v['host'] in environment_list:
                 v['host'] = "environment"
+            elif v['host'] in cattle_list:
+                v['host'] = "cattle"
+            
+            #adding in extra logic to find cattle sequences that are annotated as mammal but are cattle
             elif v['host'] in nonhuman_mammal_list:
-                v['host'] = "nonhuman_mammal"
+                if len(v['strain'].split("/")) == 5:
+                    species = v['strain'].split("/")[1]
+                    if species in cattle_list: 
+                        v['host'] = "cattle"
+                    else:
+                        v['host'] = "nonhuman_mammal"
+            
             elif v['host'] in other_list:
                 v['host'] = "other"
 


### PR DESCRIPTION
## Description of proposed changes

This is a small pull request to make `cattle` a separate host category during fauna upload. This was motivated by the recent cattle outbreaks of H5N1 in the US. Currently, host species are grouped into `avian`, `human`, `nonhuman mammal`, `environment`, and `other`. `cattle` will now be its own category. 

The changes include adding a list of cattle-related species, and adding a small test to query entries with `nonhuman mammal` annotations to find those with strain names that indicate that they are derived from cattle. 

## Checklist
I tested this with the original dairy cattle sequences from Texas, which were annotated with strain names including `dairy cattle`, but with the host field annotated as `Other Mammals`. The changes worked as expected. 