### PR TITLE
crick_upload: Skip "comments" sheets

### DIFF
--- a/tdb/crick_upload.py
+++ b/tdb/crick_upload.py
@@ -50,6 +50,10 @@ def convert_xls_to_csv(path, fstem, ind):
     exts = ['.xls', '.xlsm', '.xlsx']
     workbook = xlrd.open_workbook(path+fstem + exts[ind])
     for sheet in workbook.sheets():
+        # comments sheets are just instructions on how to use the workbook template
+        if sheet.name == 'comments':
+            print(f"Skipping sheet {sheet.name!r}", file=sys.stderr)
+            continue
         # Replace spaces with underscores in sheet name so that the call to
         # elife_upload does not error out due to the space in --fstem
         sheet.name = sheet.name.replace(' ', '_')


### PR DESCRIPTION
## Description of proposed changes

Looks like Crick has shifted to using a template workbook that includes an extra "comments" sheet which includes instructions on how to use the template. Exclude the "comments" sheet in our processing so that we don't raise unnecessary errors.

