### PR TITLE
vdb/flu_upload: update passage patterns

### DIFF
--- a/vdb/flu_upload.py
+++ b/vdb/flu_upload.py
@@ -426,7 +426,8 @@ class flu_upload(upload):
             passage_category = "undetermined"
             if re.search(r'AM[1-9]|E[1-9]|AMNIOTIC|EGG|EX|AM_[1-9]', passage):   # McWhite
                 passage_category = "egg"
-            elif re.search(r'AM-[1-9]|EMBRYO|^E$', passage):
+            # SPF = Specified Pathogen Free eggs
+            elif re.search(r'AM-[1-9]|EMBRYO|^E$|SPF\d', passage):
                 passage_category = "egg"
             elif re.search(r'LUNG|P0|OR_|ORIGINAL|CLINICAL|DIRECT', passage):    # McWhite
                 passage_category = "unpassaged"


### PR DESCRIPTION
## Description of proposed changes

Add `SPF\d` egg passage patterns to fix the passage categories for expected titer references that were reported missing on [Slack](https://bedfordlab.slack.com/archives/C03KWDET9/p1758316515093849?thread_ts=1758218156.298419&cid=C03KWDET9).

This should _not_ affect avian flu uploads since avian_flu_upload.py has it's own [format_passage method](https://github.com/nextstrain/fauna/blob/c5d8a28dd70918bcfcc8b9dc48fdf2f987be4124/vdb/avian_flu_upload.py#L618-L649).
